### PR TITLE
fix(maturity): personal late/early labels quote the bottle's own years; analytics names its two maturity layers and adds the resolved window

### DIFF
--- a/backend/src/mcp/tools/analytics.js
+++ b/backend/src/mcp/tools/analytics.js
@@ -25,7 +25,11 @@ registerTool({
     'identity, inventory, purchase, star-scale ratings, consumption, maturity, plus the USER\'S OWN typed personal ' +
     'keys and the public registry vocabulary (their keys embed an id: "personal.<id>", "registry.<id>"). Each entry ' +
     'carries type, unit, the allowed filter ops, allowed aggregations, and whether it can sort/group. Call this ' +
-    'once before composing analyze_cellar queries; field keys are exact.',
+    'once before composing analyze_cellar queries; field keys are exact. Maturity has two layers: ' +
+    'maturity.drinkFrom/drinkTo/peakFrom/peakUntil are the USER\'S OWN per-bottle overrides (null when the bottle ' +
+    'relies on the curated sommelier window, so filtering on them only sees bottles the user set a window on); ' +
+    'maturity.window* are the RESOLVED window behind the verdict (own window when set, else the curated one) and ' +
+    'maturity.status is the verdict itself — both computed per row, so columns only, never filters or groups.',
   scope: 'read',
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: {},
@@ -57,7 +61,9 @@ registerTool({
     'columns, filters and sort — use it for "which bottles" questions. Filters are {field, op, value} with field ' +
     'keys and ops exactly as list_analytics_fields declares them; date values are YYYY-MM-DD and match whole days; ' +
     'rating values are stars 0-5. Scope: cellars "all" (default) or an id subset; bottles "active" (default), ' +
-    '"consumed" or "all" — say which scope you used when presenting numbers.',
+    '"consumed" or "all" — say which scope you used when presenting numbers. "Everything at peak" cannot be ' +
+    'expressed as a filter (maturity.status is computed per row): ask what_should_i_open_tonight or cellar_stats, ' +
+    'or select maturity.status / maturity.window* as columns and read them off the rows.',
   scope: 'read',
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: {

--- a/backend/src/services/analytics/fieldCatalogue.js
+++ b/backend/src/services/analytics/fieldCatalogue.js
@@ -117,14 +117,28 @@ const STATIC_FIELDS = [
   dim({ key: 'open.openedAt', label: 'Opened date', domain: 'open', type: 'date', source: 'bottle', path: 'openedAt', groupable: false }),
   dim({ key: 'open.preservation', label: 'Preservation', domain: 'open', type: 'enum', source: 'bottle', path: 'preservationMethod', enumOptions: ['coravin', 'inert-gas', 'vacuum', 'sparkling-stopper', 'recorked'] }),
 
-  // Maturity — the user's own per-bottle window (integers, filter/sortable);
-  // the derived drink status is computed per hydrated row and says so.
-  dim({ key: 'maturity.drinkFrom', label: 'Drink from (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'drinkFrom' }),
-  dim({ key: 'maturity.drinkTo', label: 'Drink to (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'drinkTo' }),
+  // Maturity. Two layers, and the labels say which is which (support ticket
+  // 2026-09-10 — a cellar relying on curated windows read all-null dates
+  // next to status "peak" and took the null for missing data):
+  //   maturity.drinkFrom / drinkTo / peakFrom / peakUntil — the user's OWN
+  //     per-bottle overrides (integers, filter/sortable). Null whenever the
+  //     bottle relies on the sommelier profile, so a filter on them only
+  //     ever sees bottles the user set a window on.
+  //   maturity.window* — the RESOLVED window behind the status: the bottle's
+  //     own when set, else the reviewed profile (NV offsets anchored on the
+  //     bottle). Computed per hydrated row like status, so display-only.
+  //   maturity.status — the derived verdict, computed per row.
+  dim({ key: 'maturity.drinkFrom', label: 'My drink from (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'drinkFrom' }),
+  dim({ key: 'maturity.drinkTo', label: 'My drink to (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'drinkTo' }),
   // The peak pair (writable per bottle) was missing here, so a lot could not
   // be checked for matching peaks in one query (support ticket 2026-09-07).
-  dim({ key: 'maturity.peakFrom', label: 'Peak from (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'peakFrom' }),
-  dim({ key: 'maturity.peakUntil', label: 'Peak until (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'peakUntil' }),
+  dim({ key: 'maturity.peakFrom', label: 'My peak from (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'peakFrom' }),
+  dim({ key: 'maturity.peakUntil', label: 'My peak until (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'peakUntil' }),
+  dim({ key: 'maturity.windowFrom', label: 'Effective drink from (year)', domain: 'maturity', type: 'integer', source: 'computed', path: null, sortable: false, groupable: false, filterable: false }),
+  dim({ key: 'maturity.windowTo', label: 'Effective drink to (year)', domain: 'maturity', type: 'integer', source: 'computed', path: null, sortable: false, groupable: false, filterable: false }),
+  dim({ key: 'maturity.windowPeakFrom', label: 'Effective peak from (year)', domain: 'maturity', type: 'integer', source: 'computed', path: null, sortable: false, groupable: false, filterable: false }),
+  dim({ key: 'maturity.windowPeakUntil', label: 'Effective peak until (year)', domain: 'maturity', type: 'integer', source: 'computed', path: null, sortable: false, groupable: false, filterable: false }),
+  dim({ key: 'maturity.windowSource', label: 'Window source', domain: 'maturity', type: 'enum', source: 'computed', path: null, sortable: false, groupable: false, filterable: false, enumOptions: ['personal', 'profile'] }),
   // enumOptions mirror what classifyMaturity actually returns (audit F7) —
   // 'unknown' is this module's own fallback for rows with no window at all.
   dim({ key: 'maturity.status', label: 'Drink status', domain: 'maturity', type: 'enum', source: 'computed', path: null, sortable: false, groupable: false, filterable: false, enumOptions: ['not-ready', 'early', 'peak', 'late', 'declining', 'unknown'] }),

--- a/backend/src/services/analytics/queryEngine.js
+++ b/backend/src/services/analytics/queryEngine.js
@@ -44,7 +44,7 @@ const { resolveField, opsForType } = require('./fieldCatalogue');
 const { validateValue } = require('../../utils/personalDataTypes');
 const { ANCHORS, COL, toNormalized, fromNormalized } = require('../../utils/ratingUtils');
 const { getOrCreateDailySnapshot, convertCurrency } = require('../../utils/exchangeRates');
-const { classifyMaturity, buildProfileMap } = require('../../utils/maturityUtils');
+const { classifyMaturity, buildProfileMap, resolveEffectiveWindow } = require('../../utils/maturityUtils');
 
 const MAX_TIME_MS = 5000;
 const ROWS_LIMIT_MAX = 200;
@@ -837,9 +837,23 @@ async function hydrateRows({ userId, pageIds, columns, scopeCellars }) {
     return wineVint !== undefined ? wineVint : wineNull;
   };
 
-  // Maturity status only when asked for — profile map is one query.
-  const wantsMaturity = fields.some((f) => f.key === 'maturity.status');
+  // Maturity status / resolved window only when asked for — profile map is
+  // one query, and the window resolves once per row, not once per column.
+  const wantsMaturity = fields.some((f) => f.source === 'computed' && f.key.startsWith('maturity.'));
   const profileMap = wantsMaturity ? await buildProfileMap(ordered) : null;
+  const windowOf = new Map();
+  const effectiveWindow = (b) => {
+    const id = String(b._id);
+    if (!windowOf.has(id)) windowOf.set(id, resolveEffectiveWindow(b, profileMap));
+    return windowOf.get(id);
+  };
+  const WINDOW_COLUMNS = {
+    'maturity.windowFrom': 'drinkFrom',
+    'maturity.windowTo': 'drinkTo',
+    'maturity.windowPeakFrom': 'peakFrom',
+    'maturity.windowPeakUntil': 'peakUntil',
+    'maturity.windowSource': 'source',
+  };
 
   const iso = (d) => (d instanceof Date ? d.toISOString().slice(0, 10) : d ?? null);
   const extract = (b, f) => {
@@ -869,6 +883,7 @@ async function hydrateRows({ userId, pageIds, columns, scopeCellars }) {
       case 'computed': {
         if (f.key === 'bottle.cellar') return cellarNames.get(String(b.cellar)) ?? null;
         if (f.key === 'maturity.status') return classifyMaturity(b, profileMap) ?? 'unknown';
+        if (WINDOW_COLUMNS[f.key]) return effectiveWindow(b)?.[WINDOW_COLUMNS[f.key]] ?? null;
         return null;
       }
       case 'rack': {

--- a/backend/src/services/analytics/queryEngine.test.js
+++ b/backend/src/services/analytics/queryEngine.test.js
@@ -22,6 +22,7 @@ jest.mock('../../utils/exchangeRates', () => ({
 jest.mock('../../utils/maturityUtils', () => ({
   classifyMaturity: jest.fn(() => 'ready'),
   buildProfileMap: jest.fn(async () => new Map()),
+  resolveEffectiveWindow: jest.fn(() => null),
 }));
 
 const mongoose = require('mongoose');
@@ -503,6 +504,45 @@ describe('rows mode hydration', () => {
       'purchase.price': 250,
       [`personal.${KEY_ID}`]: 14.1,
     });
+  });
+
+  test('maturity.window* columns hydrate the resolved window once per row; null-safe when nothing governs', async () => {
+    const { resolveEffectiveWindow, buildProfileMap } = require('../../utils/maturityUtils');
+    const B2 = '1'.repeat(24);
+    aggReturning([{ ids: [{ _id: B1 }, { _id: B2 }], total: [{ n: 2 }] }]);
+    Bottle.find.mockReturnValue(chainLean([
+      { _id: B1, cellar: CELLAR_A, wineDefinition: { _id: W1 }, vintage: '2019' },
+      { _id: B2, cellar: CELLAR_A, wineDefinition: { _id: W1 }, vintage: '2021' },
+    ]));
+    resolveEffectiveWindow.mockImplementation((b) => (String(b._id) === B1
+      ? { source: 'profile', drinkFrom: 2024, drinkTo: 2034, peakFrom: 2026, peakUntil: 2030 }
+      : null));
+    buildProfileMap.mockClear();
+    resolveEffectiveWindow.mockClear();
+
+    const out = await runQuery(USER, {
+      columns: ['maturity.windowFrom', 'maturity.windowTo', 'maturity.windowPeakFrom', 'maturity.windowPeakUntil', 'maturity.windowSource'],
+    });
+    expect(buildProfileMap).toHaveBeenCalledTimes(1);
+    expect(resolveEffectiveWindow).toHaveBeenCalledTimes(2);
+    expect(out.rows[0].values).toEqual({
+      'maturity.windowFrom': 2024, 'maturity.windowTo': 2034,
+      'maturity.windowPeakFrom': 2026, 'maturity.windowPeakUntil': 2030,
+      'maturity.windowSource': 'profile',
+    });
+    expect(out.rows[1].values).toEqual({
+      'maturity.windowFrom': null, 'maturity.windowTo': null,
+      'maturity.windowPeakFrom': null, 'maturity.windowPeakUntil': null,
+      'maturity.windowSource': null,
+    });
+    resolveEffectiveWindow.mockImplementation(() => null);
+  });
+
+  test('maturity.window* are columns only — a filter or sort on them is refused', async () => {
+    await expect(runQuery(USER, { filters: [{ field: 'maturity.windowTo', op: 'lte', value: 2027 }] }))
+      .rejects.toMatchObject({ status: 400, message: 'Field "maturity.windowTo" is not filterable' });
+    await expect(runQuery(USER, { mode: 'rows', sort: { field: 'maturity.windowTo', dir: 'asc' } }))
+      .rejects.toMatchObject({ status: 400, message: 'Field "maturity.windowTo" is not sortable' });
   });
 
   test('a registry value hydrates from the published row only', async () => {

--- a/backend/src/utils/maturityUtils.js
+++ b/backend/src/utils/maturityUtils.js
@@ -136,6 +136,50 @@ function classifyMaturity(bottle, profileMap) {
   return 'early';
 }
 
+/**
+ * The window that actually governs a bottle's status, resolved to calendar
+ * years — the same precedence classifyMaturity applies: the bottle's OWN
+ * drinkFrom/drinkTo/peakFrom/peakUntil when any of them is set, otherwise
+ * the reviewed sommelier profile (NV offsets anchored on the bottle).
+ * Returns null when neither exists, or when a relative profile cannot be
+ * anchored — exactly the bottles classifyMaturity leaves unclassified.
+ *
+ * Analytics needed this (support ticket 2026-09-10): its maturity.* date
+ * columns are the bottle's own values, so a cellar that relies on curated
+ * windows reads all-null there while status says "peak". These are the
+ * resolved figures behind that status.
+ *
+ * @returns {{ source: 'personal'|'profile', drinkFrom, drinkTo, peakFrom, peakUntil }|null}
+ */
+function resolveEffectiveWindow(bottle, profileMap) {
+  const num = (v) => (Number.isFinite(v) ? v : null);
+  if (classifyPersonalWindow(bottle)) {
+    return {
+      source: 'personal',
+      drinkFrom: num(bottle.drinkFrom),
+      drinkTo: num(bottle.drinkTo),
+      peakFrom: num(bottle.peakFrom),
+      peakUntil: num(bottle.peakUntil),
+    };
+  }
+  const wdId    = bottle?.wineDefinition?._id?.toString() || bottle?.wineDefinition?.toString();
+  const vintage = bottle?.vintage;
+  if (!wdId || !vintage) return null;
+  const profile = profileMap?.get(`${wdId}:${vintage}`);
+  if (!profile || profile.status !== 'reviewed') return null;
+  const w = resolveWindowForBottle(profile, bottle);
+  if (!w) return null;
+  const earlyFrom = num(w.earlyFrom), peakFrom = num(w.peakFrom), peakUntil = num(w.peakUntil), lateUntil = num(w.lateUntil);
+  if (earlyFrom === null && peakFrom === null && peakUntil === null) return null;
+  return {
+    source: 'profile',
+    drinkFrom: earlyFrom ?? peakFrom,
+    drinkTo: lateUntil ?? peakUntil,
+    peakFrom,
+    peakUntil,
+  };
+}
+
 /** Build and return a WineVintageProfile lookup map for a set of active bottles. */
 async function buildProfileMap(activeBottles) {
   const seenPairs = new Set();
@@ -193,17 +237,27 @@ function maturityLabel(status, profile, bottle = null) {
   // Personal window wins: build the label from the user's own years so it is
   // consistent with the personal-window status classifyMaturity returned.
   if (bottle && classifyPersonalWindow(bottle)) {
-    const from = Number.isFinite(bottle.drinkFrom) ? bottle.drinkFrom : null;
-    const to   = Number.isFinite(bottle.drinkTo)   ? bottle.drinkTo   : null;
+    const from     = Number.isFinite(bottle.drinkFrom) ? bottle.drinkFrom : null;
+    const to       = Number.isFinite(bottle.drinkTo)   ? bottle.drinkTo   : null;
+    const peakFrom = Number.isFinite(bottle.peakFrom)  ? bottle.peakFrom  : null;
+    // Every status classifyPersonalWindow can return is handled HERE. The
+    // personal peak pair made 'early' and 'late' reachable, and for a while
+    // those two fell through to the profile labels below — so a bottle the
+    // user had recorded as finished in 2027 read "drink soon, until 2032",
+    // the shared profile's late-phase end (support ticket 2026-09-10).
     switch (status) {
       case 'not-ready':
         return `Not ready yet — drinking from ${from ?? '?'}`;
+      case 'early':
+        return peakFrom ? `Early drinking — peak from ${peakFrom}` : 'Early drinking window';
       case 'peak':
         return to ? `At peak — drink now through ${to}` : 'At peak maturity — drink now';
+      case 'late':
+        return to ? `Late maturity — drink soon, until ${to}` : 'Late maturity — drink soon';
       case 'declining':
         return 'Past peak — declining, drink immediately if at all';
       default:
-        break; // any other status → fall through to the profile-based labels
+        return null;
     }
   }
 
@@ -236,5 +290,5 @@ function maturityLabel(status, profile, bottle = null) {
 
 module.exports = {
   classifyMaturity, classifyPersonalWindow, buildProfileMap, maturityLabel,
-  bottleAnchorYear, resolveWindow, resolveWindowForBottle,
+  bottleAnchorYear, resolveWindow, resolveWindowForBottle, resolveEffectiveWindow,
 };

--- a/backend/src/utils/maturityUtils.test.js
+++ b/backend/src/utils/maturityUtils.test.js
@@ -2,7 +2,7 @@ jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
 
 const WineVintageProfile = require('../models/WineVintageProfile');
 const {
-  classifyMaturity, classifyPersonalWindow, maturityLabel,
+  classifyMaturity, classifyPersonalWindow, maturityLabel, resolveEffectiveWindow,
   buildProfileMap, bottleAnchorYear, resolveWindow,
 } = require('./maturityUtils');
 
@@ -599,6 +599,34 @@ describe('maturityLabel — personal window precedence', () => {
     expect(maturityLabel('declining', profileSaysNow, bottle)).toBe('Past peak — declining, drink immediately if at all');
   });
 
+  // Support ticket 2026-09-10: a bottle recorded as drinkTo 2027 with its
+  // peak already behind it read "Late maturity — drink soon, until 2032" —
+  // the PROFILE's lateUntil — because 'late' fell through to the profile
+  // labels. The personal peak pair makes 'early' and 'late' reachable, so
+  // both must quote the bottle's own years.
+  test('late: quotes the personal drinkTo, not the profile lateUntil', () => {
+    const bottle = { drinkFrom: 2021, peakFrom: 2022, peakUntil: 2024, drinkTo: 2027 };
+    expect(classifyPersonalWindow(bottle)).toBe('late');
+    expect(maturityLabel('late', profileSaysNow, bottle)).toBe('Late maturity — drink soon, until 2027');
+  });
+
+  test('late with no drinkTo: open-ended personal late phase has no year suffix', () => {
+    const bottle = { peakUntil: 2024 };
+    expect(classifyPersonalWindow(bottle)).toBe('late');
+    expect(maturityLabel('late', profileSaysNow, bottle)).toBe('Late maturity — drink soon');
+  });
+
+  test('early: quotes the personal peakFrom, not the profile peakFrom', () => {
+    const bottle = { drinkFrom: 2021, peakFrom: 2030, drinkTo: 2040 };
+    expect(classifyPersonalWindow(bottle)).toBe('early');
+    expect(maturityLabel('early', profileSaysNow, bottle)).toBe('Early drinking — peak from 2030');
+  });
+
+  test('a status the personal window cannot produce never leaks profile years', () => {
+    const bottle = { drinkFrom: 2021, drinkTo: 2040 };
+    expect(maturityLabel('bogus', profileSaysNow, bottle)).toBeNull();
+  });
+
   test('no personal window on the bottle → unchanged profile-based label', () => {
     const bottle = { vintage: 2020 }; // no drinkFrom/drinkTo
     expect(maturityLabel('peak', profileSaysNow, bottle)).toBe('At peak — drink now through 2028');
@@ -626,5 +654,44 @@ describe('maturityLabel — relative (NV) profiles quote resolved years', () => 
   test('no anchor → generic year-free labels, never a bare offset', () => {
     expect(maturityLabel('peak', relProfile, { vintage: 'NV' })).toBe('At peak maturity — drink now');
     expect(maturityLabel('not-ready', relProfile, { vintage: 'NV' })).toBe('Not ready yet — drinking from ?');
+  });
+});
+
+// ─── resolveEffectiveWindow ──────────────────────────────────────────────────
+// The analytics maturity.window* columns (support ticket 2026-09-10): the
+// window that governs the status, in calendar years, with its source.
+describe('resolveEffectiveWindow', () => {
+  const W = 'a'.repeat(24);
+  const profile = { status: 'reviewed', earlyFrom: 2024, earlyUntil: 2025, peakFrom: 2026, peakUntil: 2030, lateFrom: 2031, lateUntil: 2034 };
+  const map = new Map([[`${W}:2020`, profile]]);
+
+  test('a bottle with any personal field set resolves to its own window', () => {
+    const b = { drinkFrom: 2022, peakUntil: 2027, drinkTo: 2029, wineDefinition: { _id: W }, vintage: '2020' };
+    expect(resolveEffectiveWindow(b, map)).toEqual({ source: 'personal', drinkFrom: 2022, drinkTo: 2029, peakFrom: null, peakUntil: 2027 });
+  });
+
+  test('no personal window → the reviewed profile, drink span = early start to late end', () => {
+    const b = { wineDefinition: { _id: W }, vintage: '2020' };
+    expect(resolveEffectiveWindow(b, map)).toEqual({ source: 'profile', drinkFrom: 2024, drinkTo: 2034, peakFrom: 2026, peakUntil: 2030 });
+  });
+
+  test('a profile with only a peak pair spans the peak', () => {
+    const m = new Map([[`${W}:2020`, { status: 'reviewed', peakFrom: 2026, peakUntil: 2030 }]]);
+    const b = { wineDefinition: { _id: W }, vintage: '2020' };
+    expect(resolveEffectiveWindow(b, m)).toEqual({ source: 'profile', drinkFrom: 2026, drinkTo: 2030, peakFrom: 2026, peakUntil: 2030 });
+  });
+
+  test('a relative (NV) profile resolves against the purchase year', () => {
+    const m = new Map([[`${W}:NV`, { status: 'reviewed', relative: true, peakFrom: 1, peakUntil: 3, lateUntil: 5 }]]);
+    const b = { wineDefinition: { _id: W }, vintage: 'NV', purchaseDate: '2024-06-01' };
+    expect(resolveEffectiveWindow(b, m)).toEqual({ source: 'profile', drinkFrom: 2025, drinkTo: 2029, peakFrom: 2025, peakUntil: 2027 });
+  });
+
+  test('null when nothing governs: no profile, unanchored NV, unreviewed, or no wine', () => {
+    expect(resolveEffectiveWindow({ wineDefinition: { _id: W }, vintage: '2019' }, map)).toBeNull();
+    expect(resolveEffectiveWindow({ wineDefinition: { _id: W }, vintage: 'NV' }, new Map([[`${W}:NV`, { status: 'reviewed', relative: true, peakFrom: 1 }]]))).toBeNull();
+    expect(resolveEffectiveWindow({ wineDefinition: { _id: W }, vintage: '2020' }, new Map([[`${W}:2020`, { ...profile, status: 'pending' }]]))).toBeNull();
+    expect(resolveEffectiveWindow({ vintage: '2020' }, map)).toBeNull();
+    expect(resolveEffectiveWindow({ wineDefinition: { _id: W }, vintage: '2020' }, null)).toBeNull();
   });
 });


### PR DESCRIPTION
## What this changes

Support ticket 2026-09-10, two observations.

**A bug in the drink-window label.** A bottle whose own drink window put it in its late phase read "Late maturity — drink soon, until 2032" while the user had recorded drink-to 2027. The personal-window branch of `maturityLabel` only handled `not-ready` / `peak` / `declining`; the `early` and `late` statuses that the per-bottle peak pair made reachable fell through to the sommelier profile's years. Both now quote the bottle's own `peakFrom` / `drinkTo`. Covers `what_should_i_open_tonight`, `case_journey` and the cellar chat, which share the function.

**Analytics maturity fields, explained and extended.** `maturity.drinkFrom` / `drinkTo` / `peakFrom` / `peakUntil` are the user's own per-bottle overrides, null whenever a bottle relies on the curated window. A cellar built on curated windows read that as missing data next to `status: "peak"`. They are relabelled "My drink from (year)" etc., and both MCP tool descriptions now say which layer is which and point "everything at peak" at `what_should_i_open_tonight` / `cellar_stats`. New computed, columns-only fields carry the resolved window behind the status: `maturity.windowFrom`, `windowTo`, `windowPeakFrom`, `windowPeakUntil`, `windowSource` (`personal` | `profile`). Own window when set, else the reviewed profile, NV offsets anchored on the bottle's purchase year. Filters, sorts and grouping on them are refused with the usual message, like `maturity.status`. They appear in the web column picker automatically via the catalogue.

## How I tested it

- `cd backend && npm test`: 346 suites, 5288 tests pass.
- New unit tests: `maturityLabel` personal `late` / `early` / open-ended late / unknown status; `resolveEffectiveWindow` personal precedence, profile spans, peak-only profile, relative NV anchoring, all null cases; query engine hydrates `maturity.window*` once per row and refuses them as filter or sort.
- Reproduced the ticket's label before the fix with a stubbed profile (`lateUntil: 2032`) and a bottle recorded `drinkTo: 2027`, `peakUntil: 2024`.
- Not smoke-tested in Docker in this session; the author will do that locally.

## Checklist

- [ ] `cd frontend && npm test` passes (no frontend files changed)
- [x] `cd backend && npm test` passes
- [ ] Smoke-tested in Docker (`docker compose up --build`) and used the change in the app
- [ ] Commits are signed off (`git commit -s`, see CONTRIBUTING.md) — branch is in the main repository
- [x] No non-English `translation.json` files touched (those go through Weblate)
- [x] If personal data is stored, processed or shared: not applicable, no new data stored
- [x] If AI tools helped write this, that is mentioned above and I have run the result myself — written with Claude Code; tests run in the session, Docker smoke test pending by the author

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012E6hezhZCWeXf2cDw7Ju4f