### PR TITLE
fix(registry): amend a pending correction atomically; amendments carry their own reason and evidence

### DIFF
--- a/backend/src/mcp/correctionsTools.test.js
+++ b/backend/src/mcp/correctionsTools.test.js
@@ -80,7 +80,7 @@ test('an amended own suggestion is reported as such, with the full field set', a
     ok: true,
     amended: true,
     amendedFields: ['grapes'],
-    proposal: { _id: oid('7'), proposedFields: { toObject: () => ({ name: 'Château Martinat', grapes: ['Merlot', 'Malbec'] }) } },
+    proposal: { _id: oid('7'), amendments: [{ fields: ['grapes'] }], proposedFields: { toObject: () => ({ name: 'Château Martinat', grapes: ['Merlot', 'Malbec'] }) } },
     wine: { producer: 'Chateau Martinat', name: 'Grand Vin de Bordeaux' },
   });
   const res = await tool().handler({ wine_id: WINE, fields: { grapes: ['Merlot', 'Malbec'] }, reason: 'Importer data sheet.' }, CTX);
@@ -88,8 +88,14 @@ test('an amended own suggestion is reported as such, with the full field set', a
   expect(res.isError).toBeFalsy();
   expect(body.summary).toMatch(/amended with grapes/);
   expect(body.summary).toMatch(/now covers name, grapes/);
-  expect(body.data).toMatchObject({ proposal_id: oid('7'), amended: true, fields: ['name', 'grapes'], status: 'pending' });
+  expect(body.data).toMatchObject({ proposal_id: oid('7'), amended: true, fields: ['name', 'grapes'], status: 'pending', amendments: 1 });
   expect(body.data.note).toMatch(/no daily budget/);
+});
+
+test('a conflict carries the MCP-only pointer to get_wine, added by the transport', async () => {
+  ops.createFieldCorrection.mockResolvedValue({ ok: false, code: 'conflict', message: 'Filed by another user.' });
+  const res = await tool().handler({ wine_id: WINE, fields: { name: 'x' }, reason: 'long enough reason' }, CTX);
+  expect(parse(res).error.message).toBe('Filed by another user. get_wine → pending_correction shows which fields it covers.');
 });
 
 test('the description states the per-wine (not per-user) limit and the amend rule', () => {

--- a/backend/src/mcp/getWine.pendingIdentity.test.js
+++ b/backend/src/mcp/getWine.pendingIdentity.test.js
@@ -136,6 +136,13 @@ describe('get_wine — pending_correction', () => {
     expect(body.data).toHaveProperty('pending_correction', null);
   });
 
+  test('a hidden wine never reads the queue — not_found comes first', async () => {
+    WineDefinition.findOne.mockReturnValue(chain(null));
+    const res = await tool('get_wine').handler({ wine_id: WINE }, CTX);
+    expect(parse(res).error.code).toBe('not_found');
+    expect(pendingForWine).not.toHaveBeenCalled();
+  });
+
   test('the anonymous surface neither reads the queue nor carries the key', async () => {
     WineDefinition.findOne.mockReturnValue(chain(visible));
     const body = parse(await tool('get_wine').handler({ wine_id: WINE }, { anonymous: true }));

--- a/backend/src/mcp/tools/corrections.js
+++ b/backend/src/mcp/tools/corrections.js
@@ -27,7 +27,8 @@ registerTool({
     'reason saying what is wrong and how you know; an evidence URL (producer site, appellation register) makes ' +
     'one-click approval possible. Daily suggestion budget grows with the user\'s accepted contributions. ' +
     'ONE pending suggestion per wine, across ALL users: while the user\'s OWN suggestion is awaiting review, filing ' +
-    'again on that wine AMENDS it (new fields merged in, reason appended, no budget spent) — the way to add a fix ' +
+    'again on that wine AMENDS it (new fields merged in, this reason and evidence recorded as an amendment, no budget ' +
+    'spent, at most 10 amendments per suggestion) — the way to add a fix ' +
     'noticed right after filing; while SOMEONE ELSE\'s is pending the call fails with conflict. Check get_wine → ' +
     'pending_correction first: it says whether a suggestion is pending, which fields it covers and whether it is ' +
     'the caller\'s. NOT undoable via undo_last — an admin reads and decides. Sommeliers proposing merges or ' +
@@ -57,7 +58,10 @@ registerTool({
       { wineId: args.wine_id, fields: args.fields, reason: args.reason, evidenceUrl: args.evidence_url },
       { via: 'mcp', req: ctx.req }
     );
-    if (!result.ok) return fail(FAIL_CODE[result.code] || 'invalid_input', result.message);
+    if (!result.ok) {
+      const hint = result.code === 'conflict' ? ' get_wine → pending_correction shows which fields it covers.' : '';
+      return fail(FAIL_CODE[result.code] || 'invalid_input', result.message + hint);
+    }
     const pf = result.proposal.proposedFields;
     const allFields = Object.keys(pf && typeof pf.toObject === 'function' ? pf.toObject() : pf || {});
     const label = `${result.wine.producer || '?'} — ${result.wine.name}`;
@@ -69,6 +73,7 @@ registerTool({
           status: 'pending',
           amended: true,
           fields: allFields,
+          amendments: (result.proposal.amendments || []).length,
           note: 'No new queue row: the fields were merged into the suggestion already awaiting review, and no daily budget was spent.',
         }
       );

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1456,6 +1456,9 @@ registerTool({
       evidence_url: p.evidenceUrl || null,
       reason: p.reason,
       created_at: p.createdAt,
+      ...(p.amendments && p.amendments.length
+        ? { amendments: p.amendments.map((a) => ({ at: a.at, fields: a.fields || [], reason: a.reason, evidence_url: a.evidenceUrl || null })) }
+        : {}),
       ...(p.status !== 'pending' ? { decided_at: p.decidedAt, reject_reason: p.rejectReason || null, applied_note: p.appliedNote || null } : {}),
     })));
   },

--- a/backend/src/models/WineCorrectionProposal.js
+++ b/backend/src/models/WineCorrectionProposal.js
@@ -116,6 +116,29 @@ const wineCorrectionProposalSchema = new mongoose.Schema({
   // What the approve actually did (fields applied / bottles moved / queue rows
   // cleared) — the reviewer-facing receipt.
   appliedNote: { type: String, trim: true, maxlength: 500 },
+  // Later filings by the SAME proposer while the row was pending (support
+  // ticket 2026-09-12): each one merged its fields into proposedFields and is
+  // recorded here with its own reason and evidence, so the original reason
+  // and evidenceUrl stay the claim for the original fields and the admin reads
+  // the amendments as what they are. Appended atomically ($push); never
+  // rewritten. `default: undefined` keeps "never amended" distinct from [].
+  amendments: {
+    type: [new mongoose.Schema({
+      at: { type: Date, default: Date.now },
+      fields: { type: [{ type: String, trim: true, maxlength: 40 }], default: undefined },
+      reason: { type: String, trim: true, required: true, minlength: 10, maxlength: 1000 },
+      evidenceUrl: {
+        type: String,
+        trim: true,
+        maxlength: 500,
+        validate: {
+          validator: (v) => !v || /^https?:\/\//i.test(v),
+          message: 'evidenceUrl must start with http:// or https://',
+        },
+      },
+    }, { _id: false })],
+    default: undefined,
+  },
   // Which surface filed this, and which bridge key / install if it came from
   // one (utils/contributionOrigin.js).
   ...originSchemaFields(mongoose),

--- a/backend/src/routes/admin/wineProposals.js
+++ b/backend/src/routes/admin/wineProposals.js
@@ -155,6 +155,12 @@ router.get('/', async (req, res) => {
         currentSnapshot: p.currentSnapshot || null,
         evidenceUrl: p.evidenceUrl || null,
         reason: p.reason,
+        // Later filings by the same proposer, each with its own reason and
+        // evidence — the original reason/evidence above back the original
+        // fields only (support ticket 2026-09-12).
+        amendments: (p.amendments || []).map((a) => ({
+          at: a.at, fields: a.fields || [], reason: a.reason, evidenceUrl: a.evidenceUrl || null,
+        })),
         rejectReason: p.rejectReason || null,
         appliedNote: p.appliedNote || null,
         decidedAt: p.decidedAt || null,

--- a/backend/src/routes/admin/wineProposals.test.js
+++ b/backend/src/routes/admin/wineProposals.test.js
@@ -134,12 +134,38 @@ describe('GET / (list)', () => {
     expect(row.currentSnapshot.producer).toBe('Pira'); // drift is client-visible
     expect(row.proposer.username).toBe('somm1');
     expect(row.evidenceUrl).toBe('https://pira-barolo.example');
+    expect(row.amendments).toEqual([]); // never amended → empty, so the modal maps without a guard
 
     // The status filter is a literal from the static array, and the sort key
     // is the derived pending-first field.
     const pipeline = WineCorrectionProposal.aggregate.mock.calls[0][0];
     expect(pipeline[0]).toEqual({ $match: { status: 'pending' } });
     expect(pipeline.some(s => s.$sort && s.$sort._pendingFirst === 1)).toBe(true);
+  });
+
+  // Support ticket 2026-09-12: later filings by the same proposer ride along
+  // with their own reason/evidence; the original reason stays the original.
+  test('amendments are projected with their own reason and evidence, fields defaulting to []', async () => {
+    WineCorrectionProposal.aggregate.mockResolvedValue([{
+      _id: P1, kind: 'field_correction', status: 'pending',
+      proposer: { _id: ADMIN_ID, username: 'somm1' },
+      wineDefinition: { _id: W1, name: 'Barolo', producer: 'Pira', country: { name: 'Italy' }, region: { name: 'Piedmont' } },
+      proposedFields: { producer: 'E. Pira e Figli', grapes: ['Nebbiolo'] },
+      reason: 'Producer verified on the estate website.',
+      amendments: [
+        { at: '2026-09-12T08:00:00.000Z', fields: ['grapes'], reason: 'Grapes from the back label.', evidenceUrl: 'https://label.example/back' },
+        { at: '2026-09-12T09:00:00.000Z', reason: 'Second look.' },
+      ],
+      createdAt: '2026-08-09T00:00:00.000Z',
+    }]);
+    WineCorrectionProposal.countDocuments.mockResolvedValueOnce(1).mockResolvedValueOnce(1);
+
+    const row = (await (await get('?status=pending')).json()).proposals[0];
+    expect(row.reason).toBe('Producer verified on the estate website.');
+    expect(row.amendments).toEqual([
+      { at: '2026-09-12T08:00:00.000Z', fields: ['grapes'], reason: 'Grapes from the back label.', evidenceUrl: 'https://label.example/back' },
+      { at: '2026-09-12T09:00:00.000Z', fields: [], reason: 'Second look.', evidenceUrl: null },
+    ]);
   });
 });
 

--- a/backend/src/routes/bridgeV1.js
+++ b/backend/src/routes/bridgeV1.js
@@ -369,7 +369,12 @@ router.post('/corrections', quota('contributions'), async (req, res) => {
     return sendResult(res, r, (out) => {
       logAudit(req, 'bridge.correction.forwarded', { type: 'wineCorrectionProposal', id: out.proposal?._id },
         { key: req.bridge.key.id, instanceHost: req.bridge.key.instanceHost, wine: req.body?.wineId });
-      res.status(201).json({ proposal: { id: out.proposal?._id, status: out.proposal?.status || 'pending', applied: !!out.applied } });
+      // 200 + amended when the key owner's own pending proposal absorbed the
+      // fields (support ticket 2026-09-12) — the install forwards each of its
+      // user's filings, so an amendment there is an amendment here.
+      res.status(out.amended ? 200 : 201).json({
+        proposal: { id: out.proposal?._id, status: out.proposal?.status || 'pending', applied: !!out.applied, amended: !!out.amended },
+      });
     });
   } catch (error) {
     console.error('Bridge correction error:', error);

--- a/backend/src/routes/bridgeV1.test.js
+++ b/backend/src/routes/bridgeV1.test.js
@@ -256,7 +256,13 @@ describe('contributions', () => {
     const res = await call('POST', '/api/bridge/v1/corrections', { wineId: ID, fields: { producer: 'Familia Torres' }, reason: 'The label reads Familia Torres.', evidenceUrl: 'https://torres.es' });
     expect(res.status).toBe(201);
     expect(createFieldCorrection).toHaveBeenCalledWith('u1', { wineId: ID, fields: { producer: 'Familia Torres' }, reason: 'The label reads Familia Torres.', evidenceUrl: 'https://torres.es' }, expect.objectContaining({ via: 'bridge' }));
-    expect((await res.json()).proposal).toEqual({ id: 'p1', status: 'pending', applied: false });
+    expect((await res.json()).proposal).toEqual({ id: 'p1', status: 'pending', applied: false, amended: false });
+    // The key owner's own pending proposal absorbed the fields (support ticket
+    // 2026-09-12): 200, and the install learns it was an amendment.
+    createFieldCorrection.mockResolvedValue({ ok: true, amended: true, proposal: { _id: 'p1', status: 'pending' } });
+    const amended = await call('POST', '/api/bridge/v1/corrections', { wineId: ID, fields: { grapes: ['Garnacha'] }, reason: 'Back label lists Garnacha.' });
+    expect(amended.status).toBe(200);
+    expect((await amended.json()).proposal).toEqual({ id: 'p1', status: 'pending', applied: false, amended: true });
     for (const [code, status] of [['invalid', 400], ['banned', 403], ['limit', 429], ['not_found', 404], ['conflict', 409]]) {
       createFieldCorrection.mockResolvedValue({ ok: false, code, message: 'm' });
       const r = await call('POST', '/api/bridge/v1/corrections', { wineId: ID });

--- a/backend/src/routes/wineProposals.amend.test.js
+++ b/backend/src/routes/wineProposals.amend.test.js
@@ -1,0 +1,89 @@
+/**
+ * POST /api/wine-proposals — the transport half of the amend path (support
+ * ticket 2026-09-12, audit M-3): a fresh filing answers 201, an amendment of
+ * the caller's own pending suggestion answers 200 with `amended: true`, and
+ * both forward to the registry bridge (an amendment there is an amendment on
+ * the hosted side too). Service semantics live in wineProposalOps.test.js.
+ */
+
+jest.mock('../middleware/auth', () => ({
+  requireAuth: (req, _res, next) => { req.user = { id: 'a'.repeat(24), roles: ['user'] }; next(); },
+  requireNonDemo: (_req, _res, next) => next(),
+}));
+jest.mock('../services/wineProposalOps', () => ({
+  createFieldCorrection: jest.fn(),
+  listMineForWine: jest.fn(),
+}));
+jest.mock('../services/registryBridge', () => ({ forwardCorrection: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const ops = require('../services/wineProposalOps');
+const registryBridge = require('../services/registryBridge');
+const router = require('./wineProposals');
+
+const oid = (c) => c.repeat(24);
+const WINE = oid('b');
+const wine = { _id: WINE, producer: 'Chateau Martinat', name: 'Grand Vin de Bordeaux' };
+
+let server;
+let base;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/wine-proposals', router);
+  server = http.createServer(app);
+  server.listen(0, () => { base = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.close(done); });
+beforeEach(() => {
+  jest.clearAllMocks();
+  registryBridge.forwardCorrection.mockResolvedValue(undefined);
+});
+
+const post = (body) => fetch(`${base}/api/wine-proposals`, {
+  method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+});
+
+test('a fresh filing answers 201 with amended: false', async () => {
+  ops.createFieldCorrection.mockResolvedValue({
+    ok: true, amended: false, wine,
+    proposal: { _id: oid('9'), proposedFields: { name: 'Château Martinat' }, status: 'pending', createdAt: '2026-09-11T19:14:12.715Z' },
+  });
+  const res = await post({ wineId: WINE, fields: { name: 'Château Martinat' }, reason: 'Label boilerplate, not the cuvée.' });
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  expect(body).toEqual({
+    amended: false,
+    proposal: { _id: oid('9'), proposedFields: { name: 'Château Martinat' }, status: 'pending', createdAt: '2026-09-11T19:14:12.715Z' },
+  });
+  expect(ops.createFieldCorrection).toHaveBeenCalledWith(
+    oid('a'),
+    { wineId: WINE, fields: { name: 'Château Martinat' }, reason: 'Label boilerplate, not the cuvée.', evidenceUrl: undefined },
+    expect.objectContaining({ via: 'web' })
+  );
+});
+
+test('an amendment answers 200 with amended: true and still forwards to the bridge', async () => {
+  ops.createFieldCorrection.mockResolvedValue({
+    ok: true, amended: true, amendedFields: ['grapes'], wine,
+    proposal: { _id: oid('7'), proposedFields: { name: 'Château Martinat', grapes: ['Merlot', 'Malbec'] }, status: 'pending', createdAt: '2026-09-11T19:14:12.715Z' },
+  });
+  const res = await post({ wineId: WINE, fields: { grapes: ['Merlot', 'Malbec'] }, reason: 'Importer data sheet.', evidenceUrl: 'https://x.example/s' });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.amended).toBe(true);
+  expect(body.proposal.proposedFields).toEqual({ name: 'Château Martinat', grapes: ['Merlot', 'Malbec'] });
+  expect(registryBridge.forwardCorrection).toHaveBeenCalledWith(wine, {
+    fields: { grapes: ['Merlot', 'Malbec'] }, reason: 'Importer data sheet.', evidenceUrl: 'https://x.example/s',
+  });
+});
+
+test('a service failure maps to its HTTP status and nothing is forwarded', async () => {
+  ops.createFieldCorrection.mockResolvedValue({ ok: false, code: 'conflict', message: 'Filed by another user.' });
+  const res = await post({ wineId: WINE, fields: { name: 'x' }, reason: 'long enough reason' });
+  expect(res.status).toBe(409);
+  expect((await res.json()).error).toBe('Filed by another user.');
+  expect(registryBridge.forwardCorrection).not.toHaveBeenCalled();
+});

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -699,7 +699,7 @@ const REGISTRY = [
       // snapshot so it survives the wine being merged away or renamed.
       wineCorrectionProposals: markTrunc(ctx, 'wineCorrectionProposals',
         await WineCorrectionProposal.find({ proposer: ctx.userId })
-          .select('kind currentSnapshot proposedFields reason evidenceUrl status createdAt decidedAt')
+          .select('kind currentSnapshot proposedFields reason evidenceUrl amendments status createdAt decidedAt')
           .limit(EXPORT_MAX).lean())
         .map(p => ({
           kind: p.kind,

--- a/backend/src/services/wineProposalOps.js
+++ b/backend/src/services/wineProposalOps.js
@@ -17,11 +17,21 @@
  * WineCorrectionProposal). Support ticket 2026-09-12: a user who noticed a
  * second gap right after filing was told "already awaiting review" — by their
  * own suggestion. So when the pending row is the caller's OWN, a new filing
- * AMENDS it (fields merged, reason appended, snapshot refreshed) instead of
- * colliding; only somebody else's pending row is a conflict. An amendment
- * enters nothing new into the queue, so it bypasses the daily budget (not the
- * ban). `pendingForWine` exposes the same state to readers (get_wine) so the
- * block is discoverable before a correction is composed.
+ * AMENDS it instead of colliding; only somebody else's pending row is a
+ * conflict. An amendment enters nothing new into the queue, so it bypasses
+ * the daily budget (not the ban) — capped at AMENDMENTS_MAX per proposal so
+ * the bypass cannot be farmed. `pendingForWine` exposes the same state to
+ * readers (get_wine) so the block is discoverable before a correction is
+ * composed.
+ *
+ * An amendment is ONE atomic update pinned to { pending, this proposer }
+ * (audit 2026-09-12 H-1): per-field $set paths, so two amendments of
+ * different fields in the same second both land, and never a write onto a
+ * row an admin decided in between — that case falls through to a fresh
+ * filing, budget applied. The original reason and evidenceUrl are never
+ * touched; each amendment is $pushed with its own reason/evidence, and the
+ * snapshot is refreshed only for the fields being added, so drift the admin
+ * should still see on the original fields survives.
  *
  * Results are transport-neutral: { ok: true, ... } or { ok: false, code,
  * message } — codes: invalid | banned | limit | not_found | conflict.
@@ -48,6 +58,10 @@ const GRAPES_MAX = 12;
 const GRAPE_NAME_MAX = 60;
 const REASON_MIN = 10;
 const REASON_MAX = 1000;
+// Amendments bypass the daily budget (nothing new enters the queue), so they
+// are capped per proposal instead — enough for "I noticed three more gaps",
+// not enough to farm.
+const AMENDMENTS_MAX = 10;
 const FIELD_MAX = 200;
 const URL_MAX = 500;
 
@@ -128,8 +142,8 @@ async function createFieldCorrection(userId, { wineId, fields, reason, evidenceU
   // Looked up BEFORE the gate so an amendment of the caller's own pending row
   // is not refused as "one more suggestion today" — but acted on only AFTER
   // the visibility check below, so a hidden wine's queue state never leaks.
-  const existing = await findPendingForWine(wineId);
-  const amending = !!existing && String(existing.proposer) === String(userId);
+  let existing = await findPendingForWine(wineId);
+  let amending = isOwn(existing, userId);
 
   // Ban + the ONE daily budget shared across all suggestion families.
   const gate = await checkContributionGate(userId, { budget: !amending });
@@ -152,81 +166,126 @@ async function createFieldCorrection(userId, { wineId, fields, reason, evidenceU
     country: wine.country?.name || null,
     classification: wine.classification || null,
     type: wine.type || null,
-    grapes: (wine.grapes || []).map((g) => (g && g.name) || String(g)),
+    // Joined names, the shape the admin diff compares against (its liveIdentity
+    // and the somm path both join) — an array here rendered as permanent drift.
+    grapes: (wine.grapes || []).map((g) => (g && g.name) || String(g)).filter(Boolean).join(', ') || null,
   };
 
-  if (existing && !amending) {
-    return fail('conflict', 'A suggestion for this wine is already awaiting review (filed by another user — the limit is one pending suggestion per wine). ' +
-      'Wait for that decision, or check get_wine → pending_correction for what it covers.');
-  }
+  const addendum = { fields: Object.keys(proposedFields), reason: cleanReason, evidenceUrl: cleanUrl };
+  const label = `${wine.producer || '?'} — ${wine.name}`;
+  const auditMeta = { wine: label, tier: user.contribution?.tier || 'newcomer', ...(via ? { via } : {}) };
 
-  if (amending) {
-    const before = plain(existing.proposedFields);
-    const merged = { ...before, ...proposedFields };
-    const reasonSoFar = existing.reason || '';
-    const combinedReason = reasonSoFar ? `${reasonSoFar}\n\n${cleanReason}` : cleanReason;
-    if (combinedReason.length > REASON_MAX) {
-      return fail('invalid',
-        `Your pending suggestion on this wine already carries a ${reasonSoFar.length}-character reason; the addition ` +
-        `must fit in the remaining ${Math.max(0, REASON_MAX - reasonSoFar.length - 2)} characters.`);
+  // Two rounds at most: a round either settles (amend / create / conflict) or
+  // learns the queue moved under it (decided or raced) and re-reads once.
+  for (let round = 0; round < 2; round++) {
+    if (existing && !amending) return fail('conflict', OTHER_USER_CONFLICT);
+
+    if (amending) {
+      const amended = await amendOwn(existing, userId, proposedFields, currentSnapshot, addendum);
+      if (amended.ok === false) return amended;
+      if (amended.proposal) {
+        const { logAudit } = require('./audit');
+        logAudit(req || null, 'wine_proposal.user_amend',
+          { type: 'wine', id: wine._id },
+          {
+            proposalId: amended.proposal._id,
+            fields: addendum.fields,
+            allFields: Object.keys(plain(amended.proposal.proposedFields)),
+            amendments: (amended.proposal.amendments || []).length,
+            ...auditMeta,
+          });
+        return { ok: true, proposal: amended.proposal, wine, amended: true, amendedFields: addendum.fields };
+      }
+      // The row was decided while this filing was composed — it is a fresh
+      // filing now, and a fresh filing is budgeted.
+      const fresh = await checkContributionGate(userId);
+      if (!fresh.ok) return fresh;
+      existing = null;
+      amending = false;
     }
-    existing.proposedFields = merged;
-    existing.reason = combinedReason;
-    if (cleanUrl) existing.evidenceUrl = cleanUrl;
-    // The admin diff renders against LIVE values; the snapshot is what shows
-    // drift since filing — an amendment is a fresh filing of the whole set.
-    existing.currentSnapshot = currentSnapshot;
-    await existing.save();
+
+    let proposal;
+    try {
+      proposal = await WineCorrectionProposal.create({
+        proposer: userId,
+        wineDefinition: wine._id,
+        kind: 'field_correction',
+        proposedFields,
+        ...(cleanUrl ? { evidenceUrl: cleanUrl } : {}),
+        reason: cleanReason,
+        currentSnapshot,
+        ...origin,
+      });
+    } catch (err) {
+      // One pending field_correction per wine (partial unique index): a row
+      // appeared between the lookup and this insert. Whose it is decides the
+      // outcome — the caller's own (a parallel filing of theirs) is amended,
+      // never reported as "in the queue" while its fields were dropped
+      // (audit 2026-09-12 M-1).
+      if (err?.code === 11000) {
+        existing = await findPendingForWine(wineId);
+        amending = isOwn(existing, userId);
+        continue;
+      }
+      throw err;
+    }
 
     const { logAudit } = require('./audit');
-    logAudit(req || null, 'wine_proposal.user_amend',
+    logAudit(req || null, 'wine_proposal.user_create',
       { type: 'wine', id: wine._id },
-      {
-        proposalId: existing._id,
-        fields: Object.keys(proposedFields),
-        allFields: Object.keys(merged),
-        wine: `${wine.producer || '?'} — ${wine.name}`,
-        tier: user.contribution?.tier || 'newcomer',
-        ...(via ? { via } : {}),
-      });
+      { proposalId: proposal._id, fields: Object.keys(proposedFields), ...auditMeta });
 
-    return { ok: true, proposal: existing, wine, amended: true, amendedFields: Object.keys(proposedFields) };
+    return { ok: true, proposal, wine, amended: false };
   }
 
-  let proposal;
-  try {
-    proposal = await WineCorrectionProposal.create({
-      proposer: userId,
-      wineDefinition: wine._id,
-      kind: 'field_correction',
-      proposedFields,
-      ...(cleanUrl ? { evidenceUrl: cleanUrl } : {}),
-      reason: cleanReason,
-      currentSnapshot,
-      ...origin,
-    });
-  } catch (err) {
-    // One pending field_correction per wine (partial unique index) — a clean,
-    // human answer instead of a stack trace. Reached only on a race (a row
-    // appeared between the lookup above and this insert).
-    if (err?.code === 11000) {
-      return fail('conflict', 'A suggestion for this wine is already awaiting review — thank you, it is in the queue.');
-    }
-    throw err;
-  }
+  // Two rounds of the queue moving underneath — vanishingly rare; the caller
+  // retries.
+  return fail('conflict', 'The suggestion queue for this wine changed while filing — please try again.');
+}
 
-  const { logAudit } = require('./audit');
-  logAudit(req || null, 'wine_proposal.user_create',
-    { type: 'wine', id: wine._id },
+// Transport-neutral (the same text reaches the web bottle page and the MCP
+// tool); each transport adds its own pointer to where the pending state shows.
+const OTHER_USER_CONFLICT =
+  'A suggestion for this wine is already awaiting review, filed by another user — the limit is one pending ' +
+  'suggestion per wine. Wait for that decision.';
+
+const isOwn = (row, userId) => !!row && String(row.proposer) === String(userId);
+
+/**
+ * The atomic amendment. Returns { proposal } on success, { proposal: null }
+ * when the row is no longer this proposer's pending row (decided meanwhile —
+ * the caller files afresh), or a { ok: false } failure.
+ */
+async function amendOwn(existing, userId, proposedFields, currentSnapshot, addendum) {
+  if ((existing.amendments || []).length >= AMENDMENTS_MAX) {
+    return fail('limit',
+      `Your pending suggestion on this wine has been amended ${AMENDMENTS_MAX} times already — wait for the admin's decision before suggesting more.`);
+  }
+  const $set = {};
+  for (const [k, v] of Object.entries(proposedFields)) $set[`proposedFields.${k}`] = v;
+  if (existing.currentSnapshot && typeof existing.currentSnapshot === 'object') {
+    // Only the fields being added: drift the admin should still see on the
+    // original fields is not erased by a proposer who re-looked at one field.
+    for (const k of Object.keys(proposedFields)) $set[`currentSnapshot.${k}`] = currentSnapshot[k];
+  } else {
+    $set.currentSnapshot = currentSnapshot;
+  }
+  const updated = await WineCorrectionProposal.findOneAndUpdate(
+    { _id: existing._id, status: 'pending', proposer: userId, kind: 'field_correction' },
     {
-      proposalId: proposal._id,
-      fields: Object.keys(proposedFields),
-      wine: `${wine.producer || '?'} — ${wine.name}`,
-      tier: user.contribution?.tier || 'newcomer',
-      ...(via ? { via } : {}),
-    });
-
-  return { ok: true, proposal, wine, amended: false };
+      $set,
+      $push: {
+        amendments: {
+          at: new Date(),
+          fields: addendum.fields,
+          reason: addendum.reason,
+          ...(addendum.evidenceUrl ? { evidenceUrl: addendum.evidenceUrl } : {}),
+        },
+      },
+    },
+    { new: true, runValidators: true, context: 'query' }
+  );
+  return { proposal: updated || null };
 }
 
 /** A mongoose subdoc or a plain object → plain object (never null). */
@@ -246,10 +305,11 @@ function findPendingForWine(wineId) {
 
 /**
  * Read-side view of the one-pending-per-wine state, for get_wine and the
- * like: which fields a pending suggestion covers, when it was filed, and
- * whether it is the CALLER's — never whose it is otherwise (the #930
- * anonymisation rule: proposer identity stays with admins). Proposed VALUES
- * are not exposed either: the queue is not a second, unreviewed registry.
+ * like: which fields a pending suggestion covers and whether it is the
+ * CALLER's (then also when it was filed) — never whose it is otherwise (the
+ * #930 anonymisation rule: proposer identity stays with admins). Proposed
+ * VALUES are not exposed either: the queue is not a second, unreviewed
+ * registry.
  *
  * Returns null when nothing is pending. `userId` may be null (anonymous
  * caller) — then `mine` is false.
@@ -265,11 +325,10 @@ async function pendingForWine(wineId, userId) {
   const fields = Object.entries(plain(row.proposedFields))
     .filter(([, v]) => v !== undefined && v !== null && v !== '')
     .map(([k]) => k);
-  return {
-    fields,
-    filed_at: row.createdAt || null,
-    mine: !!userId && String(row.proposer) === String(userId),
-  };
+  const mine = isOwn(row, userId);
+  // filed_at only on the caller's own row: another user's filing time is one
+  // more attribute of their activity, and the block needs only the fields.
+  return { fields, mine, ...(mine ? { filed_at: row.createdAt || null } : {}) };
 }
 
 /**
@@ -285,7 +344,7 @@ async function listMineForWine(userId, wineId) {
   })
     .sort({ createdAt: -1 })
     .limit(10)
-    .select('proposedFields status reason rejectReason appliedNote createdAt decidedAt')
+    .select('proposedFields status reason rejectReason appliedNote amendments createdAt decidedAt')
     .lean();
   return { ok: true, proposals };
 }
@@ -294,6 +353,7 @@ module.exports = {
   FIELDS,
   TIER_DAILY,
   REASON_MIN,
+  AMENDMENTS_MAX,
   createFieldCorrection,
   listMineForWine,
   pendingForWine,

--- a/backend/src/services/wineProposalOps.test.js
+++ b/backend/src/services/wineProposalOps.test.js
@@ -9,7 +9,7 @@
  */
 
 jest.mock('../models/WineCorrectionProposal', () => ({
-  create: jest.fn(), countDocuments: jest.fn(), find: jest.fn(), findOne: jest.fn(),
+  create: jest.fn(), countDocuments: jest.fn(), find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(),
 }));
 // The shared contribution gate counts across ALL suggestion collections.
 jest.mock('../models/RegistryDataKey', () => ({ countDocuments: jest.fn() }));
@@ -70,15 +70,24 @@ beforeEach(() => {
   WineCorrectionProposal.create.mockResolvedValue({ _id: oid('9'), proposedFields: GOOD.fields, status: 'pending' });
 });
 
-/** A pending row as the amend path sees it — a saveable mongoose-like doc. */
+/** A pending row as the amend path reads it. */
 const pendingRow = (over = {}) => ({
   _id: oid('7'),
   proposer: ME,
   proposedFields: { toObject: () => ({ name: 'Château Martinat' }) },
   reason: 'Name field holds the label boilerplate.',
   evidenceUrl: 'https://old.example/x',
+  currentSnapshot: { producer: 'Cloudy Bay', name: 'Sauvignon Blanc', grapes: null },
   status: 'pending',
-  save: jest.fn().mockResolvedValue(undefined),
+  ...over,
+});
+/** What the atomic update hands back once it landed. */
+const updatedRow = (over = {}) => ({
+  _id: oid('7'),
+  proposer: ME,
+  proposedFields: { toObject: () => ({ name: 'Château Martinat', grapes: ['Merlot', 'Malbec'] }) },
+  amendments: [{ fields: ['grapes'], reason: 'Importer data sheet: 80% Merlot, 20% Malbec.' }],
+  status: 'pending',
   ...over,
 });
 
@@ -162,7 +171,7 @@ describe('creation', () => {
         country: 'New Zealand',
         classification: null,
         type: null,
-        grapes: [],
+        grapes: null,
       },
     }));
     expect(logAudit).toHaveBeenCalledWith(null, 'wine_proposal.user_create',
@@ -197,18 +206,34 @@ describe('creation', () => {
     expect(resolveGrapeIdsStrict).not.toHaveBeenCalled();
   });
 
-  test('the snapshot records the live type and grape names for the admin diff', async () => {
+  // Joined, not an array: the admin modal compares the snapshot against its
+  // liveIdentity (joined names) to flag drift — an array read as permanent drift
+  // (audit 2026-09-12 L-2).
+  test('the snapshot records the live type and JOINED grape names, the shape the admin diff compares', async () => {
     findVisibleWine.mockResolvedValue({ ...wineDoc, type: 'white', grapes: [{ name: 'Chardonnay' }, { name: 'Pinot Blanc' }] });
     await ops.createFieldCorrection(ME, GOOD);
     expect(WineCorrectionProposal.create).toHaveBeenCalledWith(expect.objectContaining({
-      currentSnapshot: expect.objectContaining({ type: 'white', grapes: ['Chardonnay', 'Pinot Blanc'] }),
+      currentSnapshot: expect.objectContaining({ type: 'white', grapes: 'Chardonnay, Pinot Blanc' }),
     }));
   });
 
-  test('E11000 (one pending per wine) becomes a friendly conflict', async () => {
+  test('E11000 (one pending per wine) from another user\'s racing row becomes a friendly conflict', async () => {
     WineCorrectionProposal.create.mockRejectedValue(Object.assign(new Error('dup'), { code: 11000 }));
+    WineCorrectionProposal.findOne
+      .mockResolvedValueOnce(null)                          // before the insert: nothing
+      .mockResolvedValueOnce(pendingRow({ proposer: oid('c') })); // after E11000: somebody else's
     const res = await ops.createFieldCorrection(ME, GOOD);
     expect(res).toMatchObject({ ok: false, code: 'conflict' });
+    expect(res.message).toMatch(/another user/);
+  });
+
+  test('E11000 that keeps vanishing gives up after two rounds with a retry-able conflict', async () => {
+    WineCorrectionProposal.create.mockRejectedValue(Object.assign(new Error('dup'), { code: 11000 }));
+    WineCorrectionProposal.findOne.mockResolvedValue(null);
+    const res = await ops.createFieldCorrection(ME, GOOD);
+    expect(res).toMatchObject({ ok: false, code: 'conflict' });
+    expect(res.message).toMatch(/try again/);
+    expect(WineCorrectionProposal.create).toHaveBeenCalledTimes(2);
   });
 
   test('a fresh filing reports amended: false', async () => {
@@ -218,11 +243,14 @@ describe('creation', () => {
 
 // Support ticket 2026-09-12: the one-pending rule is per WINE, and the user's
 // own suggestion was what blocked their follow-up. Own pending → amend; someone
-// else's → conflict that says so.
+// else's → conflict that says so. Audit 2026-09-12 H-1: the amendment is ONE
+// atomic update pinned to the pending row, never a hydrated save().
 describe('amending the caller\'s own pending suggestion', () => {
-  test('own pending row: fields merged, reason appended, evidence replaced, snapshot refreshed — no insert', async () => {
-    const row = pendingRow();
-    WineCorrectionProposal.findOne.mockResolvedValue(row);
+  const dup = () => Object.assign(new Error('dup'), { code: 11000 });
+
+  test('own pending row: one findOneAndUpdate pinned to {pending, proposer}, per-field $set, $push amendment — no insert', async () => {
+    WineCorrectionProposal.findOne.mockResolvedValue(pendingRow());
+    WineCorrectionProposal.findOneAndUpdate.mockResolvedValue(updatedRow());
     resolveGrapeIdsStrict.mockResolvedValue({ ok: true, ids: ['1', '2'], names: ['Merlot', 'Malbec'], substitutions: [] });
 
     const res = await ops.createFieldCorrection(ME, {
@@ -233,29 +261,39 @@ describe('amending the caller\'s own pending suggestion', () => {
     }, { via: 'mcp' });
 
     expect(res).toMatchObject({ ok: true, amended: true, amendedFields: ['grapes'] });
-    expect(res.proposal).toBe(row);
-    expect(row.proposedFields).toEqual({ name: 'Château Martinat', grapes: ['Merlot', 'Malbec'] });
-    expect(row.reason).toBe('Name field holds the label boilerplate.\n\nImporter data sheet: 80% Merlot, 20% Malbec.');
-    expect(row.evidenceUrl).toBe('https://new.example/sheet');
-    expect(row.currentSnapshot).toEqual(expect.objectContaining({ producer: 'Cloudy Bay', region: 'Marlborough' }));
-    expect(row.save).toHaveBeenCalledTimes(1);
+    expect(WineCorrectionProposal.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    const [filter, update, opts] = WineCorrectionProposal.findOneAndUpdate.mock.calls[0];
+    expect(filter).toEqual({ _id: oid('7'), status: 'pending', proposer: ME, kind: 'field_correction' });
+    // Per-field paths, so a parallel amendment of another field also lands;
+    // the snapshot is refreshed for the added field only; the original
+    // reason and evidenceUrl are NOT touched.
+    expect(update.$set).toEqual({ 'proposedFields.grapes': ['Merlot', 'Malbec'], 'currentSnapshot.grapes': null });
+    expect(update.$set).not.toHaveProperty('reason');
+    expect(update.$set).not.toHaveProperty('evidenceUrl');
+    expect(update.$set).not.toHaveProperty('proposedFields');
+    expect(update.$push.amendments).toEqual(expect.objectContaining({
+      fields: ['grapes'], reason: 'Importer data sheet: 80% Merlot, 20% Malbec.', evidenceUrl: 'https://new.example/sheet',
+    }));
+    expect(update.$push.amendments.at).toBeInstanceOf(Date);
+    expect(opts).toEqual({ new: true, runValidators: true, context: 'query' });
     expect(WineCorrectionProposal.create).not.toHaveBeenCalled();
     expect(logAudit).toHaveBeenCalledWith(null, 'wine_proposal.user_amend',
       expect.objectContaining({ type: 'wine' }),
-      expect.objectContaining({ via: 'mcp', fields: ['grapes'], allFields: ['name', 'grapes'] }));
+      expect.objectContaining({ via: 'mcp', fields: ['grapes'], allFields: ['name', 'grapes'], amendments: 1 }));
   });
 
-  test('a later value for the same field wins; evidence is kept when none is given', async () => {
-    const row = pendingRow();
-    WineCorrectionProposal.findOne.mockResolvedValue(row);
-    const res = await ops.createFieldCorrection(ME, { ...GOOD, fields: { name: 'Martinat' } });
-    expect(res.amended).toBe(true);
-    expect(row.proposedFields).toEqual({ name: 'Martinat' });
-    expect(row.evidenceUrl).toBe('https://old.example/x');
+  test('an amendment without evidence pushes no evidenceUrl key; a null snapshot is set whole', async () => {
+    WineCorrectionProposal.findOne.mockResolvedValue(pendingRow({ currentSnapshot: null }));
+    WineCorrectionProposal.findOneAndUpdate.mockResolvedValue(updatedRow());
+    await ops.createFieldCorrection(ME, GOOD);
+    const [, update] = WineCorrectionProposal.findOneAndUpdate.mock.calls[0];
+    expect(update.$push.amendments).not.toHaveProperty('evidenceUrl');
+    expect(update.$set.currentSnapshot).toEqual(expect.objectContaining({ producer: 'Cloudy Bay' }));
   });
 
   test('an amendment does NOT spend the daily budget (the ban still applies)', async () => {
     WineCorrectionProposal.findOne.mockResolvedValue(pendingRow());
+    WineCorrectionProposal.findOneAndUpdate.mockResolvedValue(updatedRow());
     WineCorrectionProposal.countDocuments.mockResolvedValue(3); // newcomer limit reached
     expect((await ops.createFieldCorrection(ME, GOOD)).amended).toBe(true);
 
@@ -263,28 +301,59 @@ describe('amending the caller\'s own pending suggestion', () => {
     expect((await ops.createFieldCorrection(ME, GOOD)).code).toBe('banned');
   });
 
-  test('a combined reason past the cap is refused, naming the room left', async () => {
-    const row = pendingRow({ reason: 'x'.repeat(990) });
-    WineCorrectionProposal.findOne.mockResolvedValue(row);
+  test('the bypass is capped: the 11th amendment is a limit, without a write', async () => {
+    WineCorrectionProposal.findOne.mockResolvedValue(pendingRow({ amendments: Array(ops.AMENDMENTS_MAX).fill({ fields: ['name'], reason: 'x'.repeat(10) }) }));
     const res = await ops.createFieldCorrection(ME, GOOD);
-    expect(res).toMatchObject({ ok: false, code: 'invalid' });
-    expect(res.message).toMatch(/990-character reason/);
-    expect(row.save).not.toHaveBeenCalled();
+    expect(res).toMatchObject({ ok: false, code: 'limit' });
+    expect(WineCorrectionProposal.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(WineCorrectionProposal.create).not.toHaveBeenCalled();
   });
 
-  test('somebody else\'s pending row is a conflict that says the limit is per wine', async () => {
+  test('row decided while composing: the pinned update misses, the filing is fresh and BUDGETED', async () => {
+    WineCorrectionProposal.findOne.mockResolvedValue(pendingRow());
+    WineCorrectionProposal.findOneAndUpdate.mockResolvedValue(null); // no longer pending
+    WineCorrectionProposal.countDocuments.mockResolvedValue(3);     // and the budget is spent
+    const res = await ops.createFieldCorrection(ME, GOOD);
+    expect(res).toMatchObject({ ok: false, code: 'limit' });
+    expect(WineCorrectionProposal.create).not.toHaveBeenCalled();
+
+    WineCorrectionProposal.countDocuments.mockResolvedValue(0);
+    const res2 = await ops.createFieldCorrection(ME, GOOD);
+    expect(res2).toMatchObject({ ok: true, amended: false });
+    expect(WineCorrectionProposal.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('E11000 from the caller\'s OWN racing row is amended, never reported as "in the queue" (audit M-1)', async () => {
+    WineCorrectionProposal.create.mockRejectedValue(dup());
+    WineCorrectionProposal.findOne
+      .mockResolvedValueOnce(null)          // before the insert: nothing
+      .mockResolvedValueOnce(pendingRow()); // after E11000: the caller's parallel filing
+    WineCorrectionProposal.findOneAndUpdate.mockResolvedValue(updatedRow());
+    const res = await ops.createFieldCorrection(ME, GOOD);
+    expect(res).toMatchObject({ ok: true, amended: true, amendedFields: ['appellation'] });
+    expect(WineCorrectionProposal.findOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test('somebody else\'s pending row is a transport-neutral conflict that says the limit is per wine', async () => {
     WineCorrectionProposal.findOne.mockResolvedValue(pendingRow({ proposer: oid('c') }));
     const res = await ops.createFieldCorrection(ME, GOOD);
     expect(res).toMatchObject({ ok: false, code: 'conflict' });
     expect(res.message).toMatch(/another user/);
     expect(res.message).toMatch(/per wine/);
+    expect(res.message).not.toMatch(/get_wine/); // the web bottle page shows this text too
     expect(WineCorrectionProposal.create).not.toHaveBeenCalled();
+    expect(WineCorrectionProposal.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
-  test('a hidden wine answers not_found even when its queue row is somebody else\'s — no leak', async () => {
-    WineCorrectionProposal.findOne.mockResolvedValue(pendingRow({ proposer: oid('c') }));
+  test.each([
+    ['somebody else\'s', oid('c')],
+    ['the caller\'s own', ME],
+  ])('a hidden wine answers not_found even when its queue row is %s — no leak, no write', async (_label, proposer) => {
+    WineCorrectionProposal.findOne.mockResolvedValue(pendingRow({ proposer }));
     findVisibleWine.mockResolvedValue(null);
     expect((await ops.createFieldCorrection(ME, GOOD)).code).toBe('not_found');
+    expect(WineCorrectionProposal.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(WineCorrectionProposal.create).not.toHaveBeenCalled();
   });
 });
 
@@ -297,35 +366,17 @@ describe('pendingForWine', () => {
     expect(await ops.pendingForWine('nope', ME)).toBeNull();
   });
 
-  test('field names, filing time and mine — never the proposer or the values', async () => {
+  test('field names and mine — filing time only on the caller\'s own row, never the proposer or the values', async () => {
     const filed = new Date('2026-09-11T19:14:12.715Z');
     WineCorrectionProposal.findOne.mockReturnValue(chain({
       proposer: ME, createdAt: filed,
       proposedFields: { producer: 'Château Martinat', name: 'Château Martinat', appellation: null, grapes: undefined },
     }));
     expect(await ops.pendingForWine(WINE, ME)).toEqual({ fields: ['producer', 'name'], filed_at: filed, mine: true });
-    expect(await ops.pendingForWine(WINE, oid('c'))).toMatchObject({ mine: false });
-    expect(await ops.pendingForWine(WINE, null)).toMatchObject({ mine: false });
+    expect(await ops.pendingForWine(WINE, oid('c'))).toEqual({ fields: ['producer', 'name'], mine: false });
+    expect(await ops.pendingForWine(WINE, null)).toEqual({ fields: ['producer', 'name'], mine: false });
     expect(WineCorrectionProposal.findOne).toHaveBeenCalledWith({
       wineDefinition: { $eq: WINE }, kind: 'field_correction', status: 'pending',
     });
-  });
-});
-
-describe('listMineForWine', () => {
-  test('caller + wine scoped, field_correction only', async () => {
-    const chain = { sort: jest.fn().mockReturnThis(), limit: jest.fn().mockReturnThis(), select: jest.fn().mockReturnThis(), lean: jest.fn().mockResolvedValue([]) };
-    WineCorrectionProposal.find.mockReturnValue(chain);
-    const res = await ops.listMineForWine(ME, WINE);
-    expect(res.ok).toBe(true);
-    expect(WineCorrectionProposal.find).toHaveBeenCalledWith({
-      proposer: ME,
-      wineDefinition: { $eq: WINE },
-      kind: 'field_correction',
-    });
-  });
-
-  test('invalid wine id rejected', async () => {
-    expect((await ops.listMineForWine(ME, 'nope')).code).toBe('invalid');
   });
 });

--- a/frontend/src/components/WineProposalsModal.js
+++ b/frontend/src/components/WineProposalsModal.js
@@ -492,6 +492,28 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
                 {p.reason}
               </div>
 
+              {/* Later filings by the same proposer (each with its own reason and
+                  evidence) — the reason above backs the original fields only. */}
+              {(p.amendments || []).map((a, i) => (
+                <div key={i} className="wp-amendment" style={{ fontSize: '0.85rem', margin: '0.35rem 0 0.35rem 0.75rem', paddingLeft: '0.5rem', borderLeft: '2px solid var(--color-border, #ccc)' }}>
+                  <div style={mutedStyle}>
+                    {t('admin.wines.proposals.amendment', {
+                      date: new Date(a.at).toLocaleDateString(),
+                      fields: (a.fields || []).map((f) => t(FIELD_KEYS[f] || f, f)).join(', '),
+                    })}
+                    {a.evidenceUrl && (
+                      <>
+                        {' · '}
+                        <a href={a.evidenceUrl} target="_blank" rel="noopener noreferrer">
+                          {t('admin.wines.proposals.evidence')}
+                        </a>
+                      </>
+                    )}
+                  </div>
+                  <div>{a.reason}</div>
+                </div>
+              ))}
+
               <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', fontSize: '0.8rem', ...mutedStyle }}>
                 {p.evidenceUrl && (
                   <a href={p.evidenceUrl} target="_blank" rel="noopener noreferrer">

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1936,6 +1936,7 @@
         "nonWineLine": "Quarantine as non-wine: hidden from search and public listings, its pending maturity-queue rows removed; owners' bottles keep working.",
         "wineGone": "(wine no longer exists)",
         "evidence": "Evidence",
+        "amendment": "Amended {{date}} · {{fields}}",
         "proposedBy": "Proposed by {{name}} on {{date}}",
         "approve": "Approve & apply",
         "approving": "Applying…",


### PR DESCRIPTION
## What this changes

Follow-up to #1287 from its audit (2026-09-12). The amend path there loaded the pending row, merged in memory and called `save()`, which `$set` the whole `proposedFields` object keyed on `_id` only:

- **H-1** Two parallel amendments (an LLM client files `name` and `grapes` in one turn) overwrote each other while both reported success; an admin approving in between left the merged fields on an already decided row, so the bottle page showed the added field as approved though it was never applied.
- **M-1** A racing fresh filing that lost the unique index was told "it is in the queue" with its field dropped.
- **M-2** Appending reasons into one 1000-char field soft-locked a wine once the stored reason passed 988 chars.
- **L-1 / L-2 / L-3 / L-4 / L-5** Evidence URL replaced the original claim's URL; snapshot grapes shape mismatched the admin diff; web users were told to check an MCP tool; the bridge answered 201 for an amendment; `filed_at` of another user's row was exposed.

Now:

- The amendment is **one `findOneAndUpdate` pinned to `{ _id, status: pending, proposer, kind }`** with per-field `$set` paths, so amendments of different fields both land and nothing is written onto a decided row. A miss falls through to a fresh, budgeted filing.
- Each amendment is `$push`ed into a new **`amendments`** array on `WineCorrectionProposal` with its own `at / fields / reason / evidenceUrl`. The original reason and evidenceUrl are never touched. Capped at 10 per proposal so the budget bypass cannot be farmed.
- On E11000 the queue is re-read: the caller's own racing row is amended, another user's is the conflict.
- The snapshot is refreshed only for the fields being added, and the user path records grapes as joined names, the shape the admin diff compares against.
- Admin list projects `amendments`; the modal renders each under the original reason with its own evidence link. `list_pending_corrections` and the GDPR export carry them too. Conflict message is transport-neutral (MCP appends its `get_wine` pointer). Bridge answers 200 + `amended`. `pending_correction.filed_at` only on the caller's own row.

## How I tested it

- `cd backend && npm test`: 347 suites, 5310 tests pass.
- `cd frontend && npm test`: 99 files, 1271 tests pass.
- Offline against the real Mongoose schema: the exact update the service issues casts cleanly and passes update validators with `context: 'query'`; a malformed one (bad `type`, short reason, `ftp://` evidence) is rejected on all three paths.
- New tests pin the update filter and shape, the decided-meanwhile fallback, the E11000 own/other split, the cap, hidden-wine ordering with an own row, REST 200/201 + bridge forward, the admin projection, and the `get_wine` hidden-wine ordering.
- Not smoke-tested in Docker.

## Checklist

- [x] `cd frontend && npm test` passes
- [x] `cd backend && npm test` passes
- [ ] Smoke-tested in Docker (`docker compose up --build`) and used the change in the app
- [ ] Commits are signed off (`git commit -s`, see CONTRIBUTING.md) — branch inside this repository, DCO check does not apply
- [x] No non-English `translation.json` files touched (those go through Weblate) — one English key added
- [x] If personal data is stored, processed or shared: export, deletion cascade, consent, audit log, minimisation and retention are covered — amendments are the proposer's own text on their own proposal; included in the account export, deleted with the proposal, audit-logged as `wine_proposal.user_amend`
- [x] If AI tools helped write this, that is mentioned above and I have run the result myself — written with Claude Code; tests run in the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F8wGCRLXXA9CFH1j1qD9V

---
_Generated by [Claude Code](https://claude.ai/code/session_011F8wGCRLXXA9CFH1j1qD9V)_