### PR TITLE
chore(release): v1.216.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.215.0",
+  "version": "1.216.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.215.0",
+      "version": "1.216.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.215.0",
+  "version": "1.216.0",
   "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.215.0",
+  "version": "1.216.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.215.0",
+      "version": "1.216.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fontsource/inter": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.215.0",
+  "version": "1.216.0",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump to v1.216.0.

Since v1.215.0:
- #1287 / #1288 — a user's own pending wine correction is amended instead of colliding; amendments carry their own reason and evidence, applied atomically; `get_wine` exposes the pending state
- #1286 — personal late/early maturity labels quote the bottle's own years; analytics names its two maturity layers and adds the resolved window
- #1283 / #1284 / #1285 — Weblate auto-merge, Estonian string recovery, French translation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)