### PR TITLE
chore(release): v1.218.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.217.0",
+  "version": "1.218.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.217.0",
+      "version": "1.218.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.217.0",
+  "version": "1.218.0",
   "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.217.0",
+  "version": "1.218.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.217.0",
+      "version": "1.218.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fontsource/inter": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.217.0",
+  "version": "1.218.0",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump to v1.218.0.

Since v1.217.0:
- #1293 — private draft wines, backend core: a wine created privately, edited freely, published to the registry as an explicit step; 7-day untouched clock; GDPR export and erasure handling
- #1294 — the web app: draft toggle on add-bottle, badge, bottle-page banner with edit and publish, attach-instead dialog, My Drafts page
- #1295 — the connector: `draft` on add_bottle / bulk_add, draft markers on reads, `list_wine_drafts`, `update_wine_draft`, `publish_wine`
- #1296 — the pre-release audit's findings (1 High, 9 Medium, Lows), all fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
