### PR TITLE
feat(tokens): a personal API token can revoke itself (DELETE /api/tokens/self)

### DIFF
--- a/backend/src/middleware/apiTokenAuth.js
+++ b/backend/src/middleware/apiTokenAuth.js
@@ -111,11 +111,21 @@ function isMcpEndpoint(method, path) {
   return (method === 'POST' || method === 'GET' || method === 'DELETE') && /^\/api\/mcp$/.test(p);
 }
 
+/**
+ * The one route EVERY personal token may reach regardless of scope: revoking
+ * itself (DELETE /api/tokens/self — routes/tokens.js). An integration being
+ * removed holds only its own bearer token; letting it end that token is
+ * strictly narrowing, never widening. Exact-anchored; /api/tokens/:id and
+ * the token list stay session-only.
+ */
+const SELF_REVOKE = { method: 'DELETE', pattern: /^\/api\/tokens\/self$/ };
+
 /** Default-deny scope check. Exported for direct unit testing. */
 function isRequestAllowed(scopes, method, path) {
   // Normalize: Express treats HEAD as GET, and a trailing slash as the same route.
   const m = method === 'HEAD' ? 'GET' : method;
   const p = path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+  if (m === SELF_REVOKE.method && SELF_REVOKE.pattern.test(p)) return true;
   if (TOKEN_EXCLUSIONS.some(rule => rule.test(p))) return false;
   for (const scope of scopes || []) {
     for (const rule of SCOPE_ALLOWLIST[scope] || []) {

--- a/backend/src/middleware/apiTokenAuth.test.js
+++ b/backend/src/middleware/apiTokenAuth.test.js
@@ -385,3 +385,20 @@ describe('authenticateApiToken', () => {
     expect(auditJson).not.toContain(RAW);
   });
 });
+
+describe('self-revoke (DELETE /api/tokens/self) is reachable by every scope, and nothing else under /api/tokens is', () => {
+  test.each([['read'], ['consume'], ['write'], ['climate']])('scope %s may revoke its own token', (scope) => {
+    expect(isRequestAllowed([scope], 'DELETE', '/api/tokens/self')).toBe(true);
+    expect(isRequestAllowed([scope], 'DELETE', '/api/tokens/self/')).toBe(true);
+  });
+
+  test('the token list, another token by id, and creating tokens stay session-only', () => {
+    for (const scope of ['read', 'consume', 'write', 'climate']) {
+      expect(isRequestAllowed([scope], 'GET', '/api/tokens')).toBe(false);
+      expect(isRequestAllowed([scope], 'DELETE', `/api/tokens/${'a'.repeat(24)}`)).toBe(false);
+      expect(isRequestAllowed([scope], 'DELETE', '/api/tokens/selfish')).toBe(false);
+      expect(isRequestAllowed([scope], 'POST', '/api/tokens')).toBe(false);
+      expect(isRequestAllowed([scope], 'GET', '/api/tokens/self')).toBe(false);
+    }
+  });
+});

--- a/backend/src/routes/tokens.js
+++ b/backend/src/routes/tokens.js
@@ -120,6 +120,35 @@ router.get('/', requireAuth, async (req, res) => {
 });
 
 // DELETE /api/tokens/:id — revoke (takes effect on the token's next request)
+// DELETE /api/tokens/self — a personal API token revokes ITSELF. An
+// integration that is being removed (the Home Assistant component on
+// "delete integration") holds only its own bearer token — no session login
+// and no token id — so this is the one way it can clean up after itself.
+// Any scope may call it (middleware/apiTokenAuth.js allow-lists exactly this
+// route for every token); a JWT session has no "self" token and is told to
+// use DELETE /api/tokens/:id. Declared BEFORE /:id so "self" never casts.
+router.delete('/self', requireAuth, async (req, res) => {
+  try {
+    if (!req.apiToken) {
+      return res.status(400).json({ error: 'Only a personal API token can revoke itself — from a signed-in session use DELETE /api/tokens/:id' });
+    }
+    const token = await ApiToken.findOne({ _id: req.apiToken.id, user: req.user.id, revokedAt: null });
+    if (!token) {
+      return res.status(404).json({ error: 'Token not found' });
+    }
+    token.revokedAt = new Date();
+    await token.save();
+
+    logAudit(req, 'token.revoked', { type: 'apiToken', id: token._id }, { name: token.name, self: true });
+    eventBus.dropToken(token._id);
+
+    res.json({ message: 'Token revoked', id: token._id, name: token.name });
+  } catch (error) {
+    console.error('Self-revoke API token error:', error);
+    res.status(500).json({ error: 'Failed to revoke token' });
+  }
+});
+
 router.delete('/:id', requireAuth, async (req, res) => {
   try {
     const token = await ApiToken.findOne({ _id: req.params.id, user: req.user.id, revokedAt: null });

--- a/backend/src/routes/tokens.test.js
+++ b/backend/src/routes/tokens.test.js
@@ -181,3 +181,50 @@ describe('DELETE /api/tokens/:id', () => {
     expect(res.status).toBe(404);
   });
 });
+
+// A personal token revoking ITSELF — what an integration being removed can do
+// with nothing but its own bearer (Home Assistant team, 2026-09-12).
+describe('DELETE /api/tokens/self', () => {
+  // requireAuth's cel_ path sets req.apiToken; here the JWT path runs and the
+  // token identity is injected ahead of the router, exactly as the middleware
+  // leaves it.
+  const withApiToken = (apiToken) => {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => { if (apiToken) req.apiToken = apiToken; next(); });
+    app.use('/api/tokens', tokensRouter);
+    return new Promise((resolve) => {
+      const s = http.createServer(app);
+      s.listen(0, async () => {
+        const res = await fetch(`http://127.0.0.1:${s.address().port}/api/tokens/self`, { method: 'DELETE', headers: { Authorization: authHeader() } });
+        const body = await res.json();
+        s.closeAllConnections(); s.close();
+        resolve({ status: res.status, body });
+      });
+    });
+  };
+
+  test('revokes exactly the calling token, audits it as a self-revoke, and drops its streams', async () => {
+    const save = jest.fn();
+    ApiToken.findOne.mockResolvedValue({ _id: 't1', name: 'Home Assistant (kitchen)', save });
+    const { status, body } = await withApiToken({ id: 't1', scopes: ['read'] });
+    expect(status).toBe(200);
+    expect(body).toEqual({ message: 'Token revoked', id: 't1', name: 'Home Assistant (kitchen)' });
+    expect(ApiToken.findOne).toHaveBeenCalledWith({ _id: 't1', user: 'u1', revokedAt: null });
+    expect(save).toHaveBeenCalled();
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'token.revoked', { type: 'apiToken', id: 't1' }, { name: 'Home Assistant (kitchen)', self: true });
+  });
+
+  test('a signed-in session has no self token → 400 pointing at /:id; never reaches the model', async () => {
+    const { status, body } = await withApiToken(null);
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/DELETE \/api\/tokens\/:id/);
+    expect(ApiToken.findOne).not.toHaveBeenCalled();
+  });
+
+  test('an already-revoked token → 404', async () => {
+    ApiToken.findOne.mockResolvedValue(null);
+    const { status } = await withApiToken({ id: 't9', scopes: ['read'] });
+    expect(status).toBe(404);
+  });
+});

--- a/docs/ha-push-events.md
+++ b/docs/ha-push-events.md
@@ -267,7 +267,10 @@ auth; JWT sessions implicitly have all scopes. Initial scopes:
 ```
 POST   /api/tokens          {name, scopes}     → {token: "cel_..."}  (shown once)
 GET    /api/tokens          → [{id, name, scopes, lastUsedAt, createdAt}]
-DELETE /api/tokens/:id      → revoke
+DELETE /api/tokens/:id      → revoke (session login)
+DELETE /api/tokens/self     → the calling token revokes ITSELF — bearer only, no
+                              session and no id; any scope. For an integration
+                              cleaning up when it is removed.
 ```
 
 Require a fresh password confirmation on create (same pattern as


### PR DESCRIPTION
## Summary

Requested by the Home Assistant integration team: the integration cannot revoke its own API token when it is removed, because token deletion needs a session login plus the token id, neither of which it has.

- **`DELETE /api/tokens/self`** (`routes/tokens.js`, declared before `/:id`) — revokes exactly the calling personal token (`req.apiToken.id`, owner-scoped, `revokedAt: null`), audits `token.revoked` with `self: true`, and fires `eventBus.dropToken` (SSE streams + MCP sessions of that token die as with any revocation). A JWT session → 400 pointing at `DELETE /api/tokens/:id`; an already-revoked token → 404.
- **Scope allow-list** (`middleware/apiTokenAuth.js`) — `SELF_REVOKE` is checked before the per-scope rules, so any scope (read / consume / write / climate) may reach exactly this route. `/api/tokens` list, `/:id`, and `POST` stay session-only. OAuth-issued tokens remain confined to the MCP endpoint (unchanged).
- `docs/ha-push-events.md` gains the route.

## Tests

- `routes/tokens.test.js` (+3): self-revoke happy path (audit `self: true`, owner-scoped lookup), session → 400 without touching the model, revoked → 404
- `middleware/apiTokenAuth.test.js` (+2): every scope reaches `DELETE /api/tokens/self` (trailing slash too); list / other ids / `selfish` / `POST` / `GET self` stay denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
