### PR TITLE
feat(wine-lists): country and region print in the list's language

### DIFF
--- a/backend/src/routes/tokens.js
+++ b/backend/src/routes/tokens.js
@@ -20,9 +20,9 @@ const authLimiter = passwordConfirmLimiter;
 // no device and 404 on every ingest, so it is not user-mintable via this route.
 const USER_MINTABLE_SCOPES = TOKEN_SCOPES.filter(s => s !== 'climate');
 
-// NOTE: none of these routes appear in the API-token scope allowlist
-// (middleware/apiTokenAuth.js), so a token can never create, list, or revoke
-// tokens — management is a logged-in-session (JWT) capability only.
+// NOTE: of these routes only DELETE /self appears in the API-token scope
+// allowlist (middleware/apiTokenAuth.js) — a token may end ITSELF and nothing
+// more; creating, listing and revoking by id are logged-in-session (JWT) only.
 
 // POST /api/tokens — create a personal API token (plaintext shown ONCE).
 // requireNonDemo: a cel_ token authenticates via apiTokenAuth (bypassing the JWT),

--- a/backend/src/services/wineListData.js
+++ b/backend/src/services/wineListData.js
@@ -4,8 +4,8 @@ const WineDefinition = require('../models/WineDefinition');
 
 const WINE_SELECT = 'name producer type appellation country region grapes classification';
 const WINE_POPULATE = [
-  { path: 'country', select: 'name' },
-  { path: 'region', select: 'name' },
+  { path: 'country', select: 'name translations' },
+  { path: 'region', select: 'name translations' },
   { path: 'grapes', select: 'name' },
 ];
 

--- a/backend/src/services/wineListPdf.js
+++ b/backend/src/services/wineListPdf.js
@@ -3,6 +3,7 @@ const QRCode = require('qrcode');
 const fs = require('fs');
 const path = require('path');
 const { entryKey } = require('./wineListData');
+const { localizedName } = require('../utils/localizedName');
 
 // Page dimensions (points, 72pt = 1 inch)
 const PAGE_SIZES = {
@@ -168,7 +169,10 @@ function buildSections(wineList, wineMap) {
   return sections;
 }
 
-function resolveEntry(entry, wineMap, layout = {}) {
+// `lang` is the LIST's language: country and region print in it where the
+// taxonomy row carries that name, else the canonical name (Toskana, but
+// Bordeaux stays Bordeaux) — support ticket 2026-09-12.
+function resolveEntry(entry, wineMap, layout = {}, lang = 'en') {
   const key = entryKey(entry);
   const info = wineMap.get(key);
   if (!info) return null; // wine no longer in the registry
@@ -181,8 +185,8 @@ function resolveEntry(entry, wineMap, layout = {}) {
     producer: wine.producer || '',
     vintage: entry.vintage || 'NV',
     bottleSize: entry.bottleSize || '750ml',
-    country: wine.country?.name || '',
-    region: wine.region?.name || '',
+    country: wine.country ? localizedName(wine.country, lang) : '',
+    region: wine.region ? localizedName(wine.region, lang) : '',
     appellation: wine.appellation || '',
     grapes: (wine.grapes || []).map(g => g.name).filter(Boolean),
     type: wine.type || '',
@@ -206,7 +210,7 @@ function buildCustomSections(wineList, wineMap) {
 
   return sorted.map(section => {
     const wines = (section.entries || [])
-      .map(e => resolveEntry(e, wineMap, layout))
+      .map(e => resolveEntry(e, wineMap, layout, wineList.language || 'en'))
       .filter(Boolean)
       .sort((a, b) => a.sortOrder - b.sortOrder);
 
@@ -232,7 +236,7 @@ function buildAutoSections(wineList, wineMap) {
   const lang = wineList.language || 'en';
 
   const wines = (wineList.autoGroupEntries || [])
-    .map(e => resolveEntry(e, wineMap, layout))
+    .map(e => resolveEntry(e, wineMap, layout, wineList.language || 'en'))
     .filter(Boolean);
 
   const out = [];

--- a/backend/src/services/wineListPdf.test.js
+++ b/backend/src/services/wineListPdf.test.js
@@ -331,3 +331,41 @@ describe('PDF page layout', () => {
     expect(priceWithSymbol('€', '16')).toBe('€16');
   });
 });
+
+// --- Geography in the list's language (support ticket 2026-09-12) ----------
+
+describe('country and region print in the list language', () => {
+  const tuscan = {
+    _id: 'g1', name: 'Brunello', producer: 'Biondi-Santi', type: 'red',
+    country: { name: 'Italy', translations: { de: 'Italien', fr: 'Italie' } },
+    region: { name: 'Tuscany', translations: { de: 'Toskana' } },
+    grapes: [],
+  };
+  const bordeaux = {
+    _id: 'g2', name: 'Pauillac', producer: 'Lynch-Bages', type: 'red',
+    country: { name: 'France', translations: { de: 'Frankreich' } },
+    region: { name: 'Bordeaux' }, // no German form — canonical stays
+    grapes: [],
+  };
+  const wineMap = new Map([mapEntry(tuscan), mapEntry(bordeaux)]);
+  const list = (language) => ({
+    structureMode: 'auto', language,
+    autoGrouping: { levels: ['type', 'country', 'region'], collapseSingle: false, withinGroup: 'name' },
+    autoGroupEntries: [entry('g1'), entry('g2')], layout: {},
+  });
+
+  test('a German list prints Italien › Toskana and Frankreich › Bordeaux; an English list is unchanged', () => {
+    const de = buildSections(list('de'), wineMap).map(s => `${'  '.repeat(s.level)}${s.title}`);
+    expect(de).toEqual(['Rotweine', '  Frankreich', '    Bordeaux', '  Italien', '    Toskana']);
+    const en = buildSections(list('en'), wineMap).map(s => `${'  '.repeat(s.level)}${s.title}`);
+    expect(en).toEqual(['Red Wines', '  France', '    Bordeaux', '  Italy', '    Tuscany']);
+  });
+
+  test('the resolved entry carries the localised names too (the producer — region line)', () => {
+    const r = resolveEntry(entry('g1'), wineMap, {}, 'de');
+    expect(r).toMatchObject({ country: 'Italien', region: 'Toskana' });
+    // A Mongoose Map (non-lean doc) works as well as a plain object
+    const mapDoc = { ...tuscan, region: { name: 'Tuscany', translations: new Map([['de', 'Toskana']]) } };
+    expect(resolveEntry(entry('g1'), new Map([mapEntry(mapDoc)]), {}, 'de-CH').region).toBe('Toskana');
+  });
+});

--- a/frontend/src/utils/wineListSections.js
+++ b/frontend/src/utils/wineListSections.js
@@ -73,7 +73,19 @@ export function groupingLevels(grouping = {}) {
 const keyOf = (e) =>
   `${e.wine?._id || e.wine}|${e.vintage || 'NV'}|${e.bottleSize || '750ml'}`;
 
-function resolveEntry(entry, winesByKey, layout = {}) {
+// A taxonomy row's name in the LIST's language where it carries one, else
+// the canonical name (mirror of backend utils/localizedName): Toskana on a
+// German menu, but Bordeaux stays Bordeaux.
+export function localName(doc, lang) {
+  if (!doc) return '';
+  const canonical = typeof doc.name === 'string' ? doc.name : '';
+  const base = String(lang || 'en').toLowerCase().split(/[-_]/)[0];
+  if (base === 'en' || !doc.translations) return canonical;
+  const t = doc.translations[base];
+  return typeof t === 'string' && t.trim() ? t.trim() : canonical;
+}
+
+function resolveEntry(entry, winesByKey, layout = {}, lang = 'en') {
   const item = winesByKey.get(keyOf(entry));
   if (!item) return null;
   if (layout.hideOutOfStock && item.stock === 0) return null;
@@ -85,8 +97,8 @@ function resolveEntry(entry, winesByKey, layout = {}) {
     producer: wine.producer || '',
     vintage: entry.vintage || 'NV',
     bottleSize: entry.bottleSize || '750ml',
-    country: wine.country?.name || '',
-    region: wine.region?.name || '',
+    country: localName(wine.country, lang),
+    region: localName(wine.region, lang),
     appellation: wine.appellation || '',
     grapes: (wine.grapes || []).map(g => g.name).filter(Boolean),
     type: wine.type || '',
@@ -166,7 +178,7 @@ function buildCustomSections(wineList, winesByKey) {
     title: section.title,
     level: 0,
     wines: (section.entries || [])
-      .map(e => resolveEntry(e, winesByKey, layout))
+      .map(e => resolveEntry(e, winesByKey, layout, wineList.language || 'en'))
       .filter(Boolean)
       .sort((a, b) => a.sortOrder - b.sortOrder),
   })).filter(s => s.wines.length > 0);
@@ -185,7 +197,7 @@ function buildAutoSections(wineList, winesByKey) {
   const lang = wineList.language || 'en';
 
   const wines = (wineList.autoGroupEntries || [])
-    .map(e => resolveEntry(e, winesByKey, layout))
+    .map(e => resolveEntry(e, winesByKey, layout, wineList.language || 'en'))
     .filter(Boolean);
 
   const out = [];

--- a/frontend/src/utils/wineListSections.test.js
+++ b/frontend/src/utils/wineListSections.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildSections, groupingLevels } from './wineListSections';
+import { buildSections, groupingLevels, localName } from './wineListSections';
 
 const WINES = {
   barolo: {
@@ -185,5 +185,35 @@ describe('nested grouping fallbacks (review 2026-09-12)', () => {
       layout: {},
     }, mapOf(item(WINES.barolo), item(chianti)));
     expect(sections.map(s => `${'  '.repeat(s.level)}${s.title}`)).toEqual(['Red Wines', '  Italy', '    Piedmont', '    Other']);
+  });
+});
+
+describe('geography in the list language (support ticket 2026-09-12)', () => {
+  const tuscan = {
+    _id: 'g1', name: 'Brunello', producer: 'Biondi-Santi', type: 'red',
+    country: { name: 'Italy', translations: { de: 'Italien' } },
+    region: { name: 'Tuscany', translations: { de: 'Toskana' } }, grapes: [],
+  };
+  const bordeaux = {
+    _id: 'g2', name: 'Pauillac', producer: 'Lynch-Bages', type: 'red',
+    country: { name: 'France', translations: { de: 'Frankreich' } },
+    region: { name: 'Bordeaux' }, grapes: [],
+  };
+  const byKey = mapOf(item(tuscan), item(bordeaux));
+
+  it('prints Toskana on a German list and leaves Bordeaux alone; English is unchanged', () => {
+    const outline = (language) => buildSections({
+      structureMode: 'auto', language,
+      autoGrouping: { levels: ['type', 'country', 'region'], collapseSingle: false, withinGroup: 'name' },
+      autoGroupEntries: [entry('g1'), entry('g2')], layout: {},
+    }, byKey).map(s => `${'  '.repeat(s.level)}${s.title}`);
+    expect(outline('de')).toEqual(['Rotweine', '  Frankreich', '    Bordeaux', '  Italien', '    Toskana']);
+    expect(outline('en')).toEqual(['Red Wines', '  France', '    Bordeaux', '  Italy', '    Tuscany']);
+  });
+
+  it('localName falls back to the canonical name', () => {
+    expect(localName({ name: 'Rioja', translations: { de: '' } }, 'de')).toBe('Rioja');
+    expect(localName({ name: 'Rioja' }, 'sv')).toBe('Rioja');
+    expect(localName(null, 'de')).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Support-ticket feature (the tractable slice of "country and region reference tables with per-language names"): the taxonomy rows already carry `translations`; the wine-list menu never read them, so a German list printed Tuscany next to Zürich.

- `services/wineListData.js` populates `name translations` for country and region.
- `services/wineListPdf.js` `resolveEntry` takes the list language and resolves country/region through `utils/localizedName` (canonical fallback — Bordeaux stays Bordeaux). Headings and the producer — region line follow; public page, PDF, MCP `get_wine_list` all agree.
- `frontend/src/utils/wineListSections.js` mirrors it (`localName`) for the editor's live preview.
- `routes/tokens.js` comment corrected (self-revoke is allow-listed since #1302).

The rest of that ticket — appellation as a table, the intake rule for appellation-in-region, propose-a-missing-region — is answered on the ticket as backlog.

## Tests

- `wineListPdf.test.js` (+2): German outline `Rotweine › Frankreich › Bordeaux / Italien › Toskana`, English unchanged; Map and plain-object translations, `de-CH` base language
- `wineListSections.test.js` (+2): same outline on the frontend mirror, `localName` fallbacks
- Frontend full suite green; backend wine-list suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
