### PR TITLE
chore(release): v1.220.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.219.0",
+  "version": "1.220.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.219.0",
+      "version": "1.220.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.219.0",
+  "version": "1.220.0",
   "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.219.0",
+  "version": "1.220.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.219.0",
+      "version": "1.220.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fontsource/inter": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.219.0",
+  "version": "1.220.0",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## v1.220.0

- fix(wine-lists): PDF footers on the page, entries and headings kept together across page breaks, new-page-per-section option, header rule clear of the QR code, "CHF 16" spacing (#1300)
- fix(mcp): a session's transport stays alive while a request is served; idempotency keys on the irreversible writes (#1301)
- feat(tokens): a personal API token can revoke itself — `DELETE /api/tokens/self` for the Home Assistant integration (#1302)
- feat(wine-lists): country and region print in the list's language (#1303)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
