### PR TITLE
fix: post-ship audit of v1.220.0 (draining MCP sessions, sibling page breaks, self-revoke edges)

### DIFF
--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -357,7 +357,7 @@ async function handleMcpRequest(req, res, ctx) {
 // false when a session cap was hit — the caller then falls back to stateless
 // mode, which degrades subscriptions only (every tool still works).
 async function initStatefulSession(req, res, ctx) {
-  const { createSession, destroySession } = require('./sessions');
+  const { createSession, destroySession, beginRequest, endRequest } = require('./sessions');
   const { snapshotRequest } = require('./requestSnapshot');
   const session = createSession({ userId: ctx.user.id, tokenId: ctx.req?.apiToken?.id });
   if (!session) return false;
@@ -382,7 +382,14 @@ async function initStatefulSession(req, res, ctx) {
     session.server = server;
     session.transport = transport;
     await server.connect(transport);
-    await transport.handleRequest(req, res, req.body);
+    // The initialize request is in flight too: with "prefer idle" eviction
+    // it would otherwise be the first one cut when a 4th client seats.
+    beginRequest(session);
+    try {
+      await transport.handleRequest(req, res, req.body);
+    } finally {
+      endRequest(session);
+    }
     return true;
   } catch (err) {
     destroySession(session.id, 'init_failed');

--- a/backend/src/mcp/sessions.js
+++ b/backend/src/mcp/sessions.js
@@ -28,8 +28,16 @@ const ABSOLUTE_TTL_MS = 2 * 60 * 60 * 1000; // hard cap; also bounds stale-scope
 const SWEEP_EVERY_MS = 60 * 1000;
 
 const sessions = new Map(); // sessionId -> session
+// Unrouted sessions whose transport is kept open for a request still being
+// served on it (see destroySession). Revocation and the sweeper scan this
+// too — a draining session must never outlive its credential, or a hung
+// handler (post-ship audit 2026-09-12, M1).
+const draining = new Map(); // sessionId -> session
 let perUserCounts = new Map(); // userIdString -> n
 let sweepTimer = null;
+// A drain older than this is force-closed: no legitimate tool call runs
+// for minutes, so the request is hung and the transport would leak.
+const DRAIN_MAX_MS = 5 * 60 * 1000;
 
 function ensureSweeper() {
   if (sweepTimer) return;
@@ -40,7 +48,10 @@ function ensureSweeper() {
         destroySession(s.id, 'expired');
       }
     }
-    if (sessions.size === 0 && sweepTimer) {
+    for (const s of [...draining.values()]) {
+      if (now - s.drainingSince > DRAIN_MAX_MS) closeSessionIo(s, `${s.pendingDestroy}_drain_timeout`);
+    }
+    if (sessions.size === 0 && draining.size === 0 && sweepTimer) {
       clearInterval(sweepTimer);
       sweepTimer = null;
     }
@@ -159,6 +170,7 @@ function endRequest(session) {
 
 function closeSessionIo(s, reason) {
   s.pendingDestroy = null;
+  draining.delete(s.id);
   try { s.busUnsub?.(); } catch { /* already gone */ }
   // Close transport+server asynchronously; a rejected close must never crash
   // the hot path (same rationale as the stateless per-request teardown).
@@ -179,6 +191,9 @@ function destroySession(sessionId, reason = 'closed') {
   else perUserCounts.set(s.userId, left);
   if ((s.inFlight || 0) > 0 && !IMMEDIATE_REASONS.has(reason)) {
     s.pendingDestroy = reason;
+    s.drainingSince = Date.now();
+    draining.set(s.id, s);
+    ensureSweeper(); // bounds the drain even when the routed map is empty
     console.log(`[mcp] session ${s.id.slice(0, 8)} unrouted (${reason}) — ${s.inFlight} request(s) in flight, transport kept until they finish`);
     return true;
   }
@@ -186,10 +201,15 @@ function destroySession(sessionId, reason = 'closed') {
   return true;
 }
 
+// Credential gone: every session of that user/token closes NOW — routed or
+// draining. A draining transport must not keep serving a revoked credential.
 function dropUserSessions(userId) {
   const key = String(userId);
   for (const s of [...sessions.values()]) {
     if (s.userId === key) destroySession(s.id, 'user_dropped');
+  }
+  for (const s of [...draining.values()]) {
+    if (s.userId === key) closeSessionIo(s, 'user_dropped');
   }
 }
 
@@ -197,6 +217,9 @@ function dropTokenSessions(tokenId) {
   const id = String(tokenId);
   for (const s of [...sessions.values()]) {
     if (s.tokenId === id) destroySession(s.id, 'token_revoked');
+  }
+  for (const s of [...draining.values()]) {
+    if (s.tokenId === id) closeSessionIo(s, 'token_revoked');
   }
 }
 
@@ -207,12 +230,12 @@ eventBus.onDropToken(dropTokenSessions);
 
 /** Counts for tests/ops. */
 function sessionCounts() {
-  return { total: sessions.size, users: perUserCounts.size };
+  return { total: sessions.size, users: perUserCounts.size, draining: draining.size };
 }
 
 module.exports = {
   createSession, getSession, destroySession, sessionCounts,
   beginRequest, endRequest,
   dropUserSessions, dropTokenSessions,
-  MAX_SESSIONS_PER_USER, MAX_SESSIONS_GLOBAL, IDLE_TTL_MS, ABSOLUTE_TTL_MS,
+  MAX_SESSIONS_PER_USER, MAX_SESSIONS_GLOBAL, IDLE_TTL_MS, ABSOLUTE_TTL_MS, DRAIN_MAX_MS,
 };

--- a/backend/src/mcp/sessions.test.js
+++ b/backend/src/mcp/sessions.test.js
@@ -187,3 +187,45 @@ describe('in-flight requests (support ticket 2026-09-12: "session expired" after
     expect(sessions.getSession(busy.id, { userId: 'u1', tokenId: null })).toBe(busy);
   });
 });
+
+describe('draining sessions (post-ship audit 2026-09-12 M1)', () => {
+  test('a revoked token closes a DRAINING session at once — a deferred close never outlives its credential', async () => {
+    const s = sessions.createSession({ userId: 'u1', tokenId: 'tok1' });
+    s.transport = mkTransport();
+    sessions.beginRequest(s);
+    sessions.destroySession(s.id, 'evicted_for_new_session'); // deferred: request in flight
+    expect(sessions.sessionCounts()).toMatchObject({ total: 0, draining: 1 });
+    expect(s.transport.close).not.toHaveBeenCalled();
+    eventBus.dropToken('tok1');
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.transport.close).toHaveBeenCalled();
+    expect(sessions.sessionCounts().draining).toBe(0);
+    // The late endRequest is a no-op — nothing closes twice
+    sessions.endRequest(s);
+    await Promise.resolve();
+    expect(s.transport.close).toHaveBeenCalledTimes(1);
+  });
+
+  test('a password change (dropUser) reaches draining sessions too', async () => {
+    const s = sessions.createSession({ userId: 'u1' });
+    s.transport = mkTransport();
+    sessions.beginRequest(s);
+    sessions.destroySession(s.id, 'expired');
+    eventBus.dropUser('u1');
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.transport.close).toHaveBeenCalled();
+  });
+
+  test('a hung request cannot keep a drain open forever: the sweeper force-closes it after DRAIN_MAX_MS', async () => {
+    const s = sessions.createSession({ userId: 'u1' });
+    s.transport = mkTransport();
+    sessions.beginRequest(s);
+    sessions.destroySession(s.id, 'evicted_for_new_session');
+    jest.advanceTimersByTime(sessions.DRAIN_MAX_MS - 30 * 1000);
+    expect(s.transport.close).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(2 * 60 * 1000);
+    await Promise.resolve(); await Promise.resolve();
+    expect(s.transport.close).toHaveBeenCalled();
+    expect(sessions.sessionCounts().draining).toBe(0);
+  });
+});

--- a/backend/src/middleware/apiTokenAuth.test.js
+++ b/backend/src/middleware/apiTokenAuth.test.js
@@ -402,3 +402,36 @@ describe('self-revoke (DELETE /api/tokens/self) is reachable by every scope, and
     }
   });
 });
+
+// The real middleware path for the self-revoke route (post-ship audit
+// 2026-09-12 L2): the OAuth audience confinement must run BEFORE the
+// self-revoke short-circuit, and a personal token must reach the handler
+// with a string id.
+describe('authenticateApiToken × DELETE /api/tokens/self', () => {
+  const RAW = 'cel_' + 'e'.repeat(64);
+  const mockRes = () => { const res = { status: jest.fn(() => res), json: jest.fn(() => res) }; return res; };
+  const req = () => ({ method: 'DELETE', baseUrl: '/api/tokens', path: '/self', headers: {} });
+  const selectable = (doc) => ({ select: jest.fn().mockResolvedValue(doc) });
+  const user = { _id: { toString: () => 'u1' }, roles: ['user'], plan: 'free', planExpiresAt: null, deletionScheduledFor: null };
+
+  test('an OAuth-issued token is confined to the MCP endpoint — 403, never the handler', async () => {
+    ApiToken.findOne.mockResolvedValue({ _id: { toString: () => 't1' }, user: 'u1', scopes: ['read', 'write'], origin: 'oauth', lastUsedAt: null });
+    User.findById.mockReturnValue(selectable(user));
+    const r = req(); const res = mockRes(); const next = jest.fn();
+    await authenticateApiToken(r, res, next, RAW);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json.mock.calls[0][0].error).toMatch(/MCP endpoint/);
+  });
+
+  test('a personal token of ANY scope reaches the handler with a string id', async () => {
+    for (const scopes of [['read'], ['consume'], ['climate']]) {
+      ApiToken.findOne.mockResolvedValue({ _id: { toString: () => 't1' }, user: 'u1', scopes, lastUsedAt: null });
+      User.findById.mockReturnValue(selectable(user));
+      const r = req(); const res = mockRes(); const next = jest.fn();
+      await authenticateApiToken(r, res, next, RAW);
+      expect(next).toHaveBeenCalled();
+      expect(r.apiToken).toEqual({ id: 't1', scopes });
+    }
+  });
+});

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -369,6 +369,9 @@ router.post('/activity/:id/revert', requireAuth, requireNonDemo, async (req, res
     if (!row) return res.status(404).json({ error: 'No such AI action on your account.' });
     if (row.reversed) return res.status(409).json({ error: 'That action has already been reverted.' });
     if (row.viaUndo) return res.status(400).json({ error: 'That entry is itself a revert and cannot be reverted.' });
+    if (!REVERSIBLE_ACTIONS.has(row.action)) {
+      return res.status(409).json({ error: 'That action cannot be reverted: it reached a human queue or the shared registry (a support ticket, a wine request, a suggestion). Reply on the ticket or wait for the review instead.' });
+    }
     if (!isRevertible(row)) {
       return res.status(409).json({ error: 'That action is too old to revert automatically. Adjust the bottle in your cellar directly.' });
     }

--- a/backend/src/routes/tokens.js
+++ b/backend/src/routes/tokens.js
@@ -132,6 +132,14 @@ router.delete('/self', requireAuth, async (req, res) => {
     if (!req.apiToken) {
       return res.status(400).json({ error: 'Only a personal API token can revoke itself — from a signed-in session use DELETE /api/tokens/:id' });
     }
+    // A climate device token is bound to a ClimateDevice row: it is minted
+    // and retired through the device routes (DELETE /api/climate/devices/:id
+    // revokes + purges + deletes). Ending only the token here would leave a
+    // device that can never post again, still counted and still alerting
+    // "offline" (post-ship audit 2026-09-12).
+    if ((req.apiToken.scopes || []).includes('climate')) {
+      return res.status(403).json({ error: 'A climate device token is retired by deleting its device (DELETE /api/climate/devices/:id), not by revoking the token alone' });
+    }
     const token = await ApiToken.findOne({ _id: req.apiToken.id, user: req.user.id, revokedAt: null });
     if (!token) {
       return res.status(404).json({ error: 'Token not found' });

--- a/backend/src/routes/tokens.test.js
+++ b/backend/src/routes/tokens.test.js
@@ -228,3 +228,24 @@ describe('DELETE /api/tokens/self', () => {
     expect(status).toBe(404);
   });
 });
+
+describe('DELETE /api/tokens/self refuses a climate device token (post-ship audit 2026-09-12)', () => {
+  test('a device token is retired through its device, not here — 403 and no write', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => { req.apiToken = { id: 't5', scopes: ['climate'] }; next(); });
+    app.use('/api/tokens', tokensRouter);
+    const { status, body } = await new Promise((resolve) => {
+      const s = http.createServer(app);
+      s.listen(0, async () => {
+        const res = await fetch(`http://127.0.0.1:${s.address().port}/api/tokens/self`, { method: 'DELETE', headers: { Authorization: authHeader() } });
+        const b = await res.json();
+        s.closeAllConnections(); s.close();
+        resolve({ status: res.status, body: b });
+      });
+    });
+    expect(status).toBe(403);
+    expect(body.error).toMatch(/climate\/devices/);
+    expect(ApiToken.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/wineListPdf.js
+++ b/backend/src/services/wineListPdf.js
@@ -354,11 +354,24 @@ async function generateWineListPdf(wineList, wineMap, opts = {}) {
   const legacySubHeaders = levelsInForce.length === 1 && levelsInForce[0] === 'type' &&
     wineList.autoGrouping?.withinGroup === 'country-region-name';
   let anyLastBottle = false;
-  // Approximate heights of a heading per level, and of the first entry —
-  // a heading stack (type › country › region) breaks the page as ONE unit
-  // so no heading is ever orphaned at the foot of a page.
-  const HEADING_HEIGHT = [42, 22, 15];
+  // A heading stack (type › country › region) breaks the page as ONE unit
+  // so no heading is ever orphaned at the foot of a page. Heading heights
+  // are measured with the font renderHeading uses plus its spacing; the
+  // first entry is renderWineEntry's tallest advance.
   const FIRST_ENTRY_HEIGHT = 26;
+  const headingHeight = (section) => {
+    const level = section.level || 0;
+    if (level === 0) {
+      doc.font(fontBold).fontSize(13);
+      return doc.heightOfString(String(section.title).toUpperCase(), { width: contentWidth }) + 30;
+    }
+    if (level === 1) {
+      doc.font(fontBold).fontSize(10.5);
+      return doc.heightOfString(String(section.title), { width: contentWidth - 10 }) + 12;
+    }
+    doc.font(fontItalic).fontSize(9);
+    return doc.heightOfString(String(section.title), { width: contentWidth - 20 }) + 8;
+  };
   // Content must stay above this line: everything written below the bottom
   // margin makes PDFKit open a new page by itself.
   const bottomLimit = pageSize[1] - margin;
@@ -404,23 +417,27 @@ async function generateWineListPdf(wineList, wineMap, opts = {}) {
   for (let i = 0; i < sections.length; i++) {
     const section = sections[i];
     const level = section.level || 0;
+    // Ancestors only while deciding the break: a break placed between two
+    // sibling groups repeats the parents ("RED WINES (continued) › Italy
+    // (continued)") before the new sibling — post-ship audit 2026-09-12.
     stack.length = level;
-    stack[level] = section;
 
     if (level === 0 && i > 0 && newPageEachSection) {
       breakPage({ repeatHeadings: false });
     } else {
       // Room for this heading, the deeper headings that follow it before the
-      // first wine, and that wine — else start a new page here.
-      let need = HEADING_HEIGHT[Math.min(level, 2)] + FIRST_ENTRY_HEIGHT;
+      // first wine, and that wine — else start a new page here. Heights are
+      // MEASURED (a long title wraps), not guessed.
+      let need = headingHeight(section) + FIRST_ENTRY_HEIGHT;
       for (let k = i + 1; k < sections.length && (sections[k].level || 0) > level && !section.wines.length; k++) {
-        need += HEADING_HEIGHT[Math.min(sections[k].level || 0, 2)];
+        need += headingHeight(sections[k]);
         if (sections[k].wines.length) break;
       }
       if (doc.y > bottomLimit - Math.max(need, level === 0 ? 80 : 0)) {
-        breakPage({ repeatHeadings: false });
+        breakPage({ repeatHeadings: level > 0 });
       }
     }
+    stack[level] = section;
 
     renderHeading(section, { first: i === 0 || doc.y <= margin + 1 });
 
@@ -506,9 +523,9 @@ function entryHeight(wine) {
   return [producerRegion, grapes].filter(Boolean).length ? 26 : 15;
 }
 
-/** "CHF 16" but "$16": a space after a symbol made of letters, none after a sign. */
+/** "CHF 16", "zł 160", "Fr. 16" but "$16": a space after a symbol ending in a letter (any script) or a dot, none after a sign. */
 function priceWithSymbol(symbol, amount) {
-  const sep = /[A-Za-z]$/.test(symbol) ? ' ' : '';
+  const sep = /[\p{L}.]$/u.test(symbol) ? ' ' : '';
   return `${symbol}${sep}${amount}`;
 }
 

--- a/backend/src/services/wineListPdf.test.js
+++ b/backend/src/services/wineListPdf.test.js
@@ -369,3 +369,49 @@ describe('country and region print in the list language', () => {
     expect(resolveEntry(entry('g1'), new Map([mapEntry(mapDoc)]), {}, 'de-CH').region).toBe('Toskana');
   });
 });
+
+
+// --- Post-ship audit 2026-09-12 -----------------------------------------------
+
+describe('page breaks between sibling groups (post-ship audit 2026-09-12)', () => {
+  test('a page never opens on a bare nested heading: the parents come first, marked continued', async () => {
+    // Italy with three regions and Spain with one, three levels, no collapse —
+    // enough pages that breaks land both mid-group and between siblings.
+    const wines = [];
+    for (const [country, region, n] of [['Italy', 'Piedmont', 30], ['Italy', 'Tuscany', 30], ['Italy', 'Veneto', 30], ['Spain', 'Rioja', 30]]) {
+      for (let i = 0; i < n; i++) {
+        wines.push({ _id: `${region}${i}`, name: `${region} wine ${String(i).padStart(2, '0')}`, producer: `P${i}`, type: 'red', country: { name: country }, region: { name: region }, grapes: [] });
+      }
+    }
+    const wineMap = new Map(wines.map(w => mapEntry(w)));
+    const PDFDocument = require('pdfkit');
+    const events = [];
+    const origText = PDFDocument.prototype.text;
+    const origAdd = PDFDocument.prototype.addPage;
+    const spyT = jest.spyOn(PDFDocument.prototype, 'text').mockImplementation(function (s, ...r) { events.push(['text', String(s)]); return origText.call(this, s, ...r); });
+    const spyA = jest.spyOn(PDFDocument.prototype, 'addPage').mockImplementation(function (...r) { events.push(['page']); return origAdd.apply(this, r); });
+    try {
+      await pdfBytes(await generateWineListPdf({
+        name: 'T', structureMode: 'auto', language: 'en',
+        autoGrouping: { levels: ['type', 'country', 'region'], collapseSingle: false, withinGroup: 'name' },
+        autoGroupEntries: wines.map(w => entry(w._id)), layout: {}, branding: {},
+      }, wineMap));
+    } finally { spyT.mockRestore(); spyA.mockRestore(); }
+    const breaks = events.map((e, i) => (e[0] === 'page' ? i : -1)).filter(i => i > 0);
+    expect(breaks.length).toBeGreaterThan(3);
+    for (const b of breaks) {
+      const next = events.slice(b + 1).find(e => e[0] === 'text' && !/^[.$]/.test(e[1]));
+      // Either a fresh section (uppercase level-0 title) or a continued stack starting at the top
+      expect(next[1]).toMatch(/^RED WINES( \(CONTINUED\))?$/);
+    }
+    // Every wine written exactly once
+    expect(events.filter(e => e[0] === 'text' && /wine \d\d, NV$/.test(e[1]))).toHaveLength(120);
+  });
+
+  test('priceWithSymbol handles non-ASCII letters and a trailing dot', () => {
+    expect(priceWithSymbol('zł', '160')).toBe('zł 160');
+    expect(priceWithSymbol('Kč', '160')).toBe('Kč 160');
+    expect(priceWithSymbol('Fr.', '16')).toBe('Fr. 16');
+    expect(priceWithSymbol('£', '16')).toBe('£16');
+  });
+});

--- a/docs/ha-push-events.md
+++ b/docs/ha-push-events.md
@@ -269,8 +269,11 @@ POST   /api/tokens          {name, scopes}     → {token: "cel_..."}  (shown on
 GET    /api/tokens          → [{id, name, scopes, lastUsedAt, createdAt}]
 DELETE /api/tokens/:id      → revoke (session login)
 DELETE /api/tokens/self     → the calling token revokes ITSELF — bearer only, no
-                              session and no id; any scope. For an integration
-                              cleaning up when it is removed.
+                              session and no id; any personal scope (a climate
+                              device token is retired via its device instead).
+                              For an integration cleaning up when it is removed.
+                              Treat 401 as "already gone": it also answers 401
+                              while the account is in its deletion cooling-off.
 ```
 
 Require a fresh password confirmation on create (same pattern as

--- a/frontend/src/components/WineListMenu.js
+++ b/frontend/src/components/WineListMenu.js
@@ -41,8 +41,8 @@ function WineListMenu({ branding = {}, layout = {}, language = 'en', sections = 
   // exist. With prices hidden, a by-the-glass wine still says so.
   const renderPrice = (wine) => {
     if (hidePrices) return wine.byGlass ? glassLabel : null;
-    // "CHF 16" but "$16": a space after a symbol made of letters, none after a sign
-    const sym = /[A-Za-z]$/.test(currencySymbol) ? `${currencySymbol} ` : currencySymbol;
+    // "CHF 16", "zł 160", "Fr. 16" but "$16": a space after a symbol ending in a letter (any script) or a dot
+    const sym = /[\p{L}.]$/u.test(currencySymbol) ? `${currencySymbol} ` : currencySymbol;
     const parts = [];
     if (wine.price != null) parts.push(`${sym}${Math.round(wine.price)}`);
     if (wine.glassPrice != null) parts.push(`${sym}${Math.round(wine.glassPrice)} ${glassLabel}`);


### PR DESCRIPTION
## Summary

Post-ship audit of v1.220.0 (three reviewer agents over `v1.219.0..v1.220.0`, findings verified before fixing): 0 High, 2 Medium, 6 Low. All fixed here.

**MCP sessions (#1301 follow-up)**
- **Medium** — a deferred-close (draining) session was removed from the session map, so `dropUser`/`dropToken` could not reach it and a hung handler would leak its transport forever. Now: a `draining` map; revocation closes draining sessions immediately; the sweeper force-closes drains older than `DRAIN_MAX_MS` (5 min); `sessionCounts().draining` exposed.
- **Low** — the stateful `initialize` request is counted in flight (was the first eviction target under "prefer idle").
- **Low** — browser revert on a human-queue row (support ticket, suggestion …) now answers "cannot be reverted" instead of "too old".

**Wine-list PDF (#1300 follow-up)**
- **Medium** — a page break placed *between* sibling groups opened the page on a bare nested heading; the ancestors are now repeated `(continued)` first (`stack.length = level` before the fit check, `repeatHeadings: level > 0`).
- **Low** — heading reserves are measured with `doc.heightOfString` per level instead of fixed constants (wrapped titles kept their stack only by fractions of a point).
- **Low** — `priceWithSymbol` / menu: `/[\p{L}.]$/u` ("zł 160", "Kč 160", "Fr. 16"; "£16" unchanged).

**Token self-revoke (#1302 follow-up)**
- **Low** — a `climate` device token gets 403 on `/self` (retire via `DELETE /api/climate/devices/:id`, which also purges readings and the device row).
- **Low** — `authenticateApiToken` × `DELETE /api/tokens/self` pinned: OAuth token → 403 (audience confinement runs before the self-revoke short-circuit), personal token of any scope reaches the handler with a string id.
- **Low** — doc: treat 401 on `/self` as "already gone" (also answered during an account's deletion cooling-off).

Not changed (informational): live transports can briefly exceed the session cap by the number of draining sessions (bounded by the in-flight limiter); the editor picker keeps English geography while the preview uses the list language.

## Tests

- `sessions.test.js` (+3): revoked token closes a draining session, dropUser reaches drains, sweeper force-closes a hung drain
- `wineListPdf.test.js` (+2): 120-wine three-level list — every page opens on `RED WINES` or `RED WINES (CONTINUED)`, never a bare nested heading; symbol regex
- `apiTokenAuth.test.js` (+2), `tokens.test.js` (+1) as above
- Backend MCP/token/PDF suites green; frontend suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
